### PR TITLE
Fe/feature/#86 tailwindcss theme 설정

### DIFF
--- a/frontend/src/tailwind.css
+++ b/frontend/src/tailwind.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@500;700&display=swap');
+
+@layer base {
+  html {
+    font-family: 'Noto Sans KR', sans-serif;
+  }
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -6,19 +6,40 @@ export default {
   },
   plugins: [
     ({ addComponents }) => {
+      const themeBase = {
+        bold_L: { fontWeight: '700', fontSize: '24px' },
+        bold_M: { fontWeight: '700', fontSize: '16px' },
+        bold_R: { fontWeight: '700', fontSize: '14px' },
+        bold_S: { fontWeight: '700', fontSize: '12px' },
+        medium_M: { fontWeight: '500', fontSize: '16px' },
+        medium_R: { fontWeight: '500', fontSize: '14px' },
+        medium_S: { fontWeight: '500', fontSize: '12px' },
+      };
+      
       const textTheme = {
         '.text-strong': { color: '#14212B' },
         '.text-bold': { color: '#4B5966' },
         '.text-default': { color: '#5E6E76' },
         '.text-weak': { color: '#879298' },
         '.text-white-default': { color: '#FFFFFF' },
-        '.bold24': { fontWeight: '700', fontSize: '24px' },
-        '.bold16': { fontWeight: '700', fontSize: '16px' },
-        '.bold14': { fontWeight: '700', fontSize: '14px' },
-        '.bold12': { fontWeight: '700', fontSize: '12px' },
-        '.medium16': { fontWeight: '500', fontSize: '16px' },
-        '.medium14': { fontWeight: '500', fontSize: '14px' },
-        '.medium12': { fontWeight: '500', fontSize: '12px' }
+        '.display-bold24': themeBase.bold_L,
+        '.display-bold16': themeBase.bold_M,
+        '.display-bold14': themeBase.bold_R,
+        '.display-bold12': themeBase.bold_S,
+        '.display-medium16': themeBase.medium_M,
+        '.display-medium14': themeBase.medium_R,
+        '.display-medium12': themeBase.medium_S,
+        '.available-medium16': themeBase.medium_M,
+        '.available-medium14': themeBase.medium_R,
+        '.available-medium12': themeBase.medium_S,
+        '.hover-medium16': {
+          ...themeBase.medium_M,
+          textDecoration: 'underline'
+        },
+        '.hover-medium14': {
+          ...themeBase.medium_R,
+          textDecoration: 'underline'
+        }
       };
       addComponents(textTheme);
     },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,5 +4,50 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    ({ addComponents }) => {
+      const textTheme = {
+        '.text-strong': { color: '#14212B' },
+        '.text-bold': { color: '#4B5966' },
+        '.text-default': { color: '#5E6E76' },
+        '.text-weak': { color: '#879298' },
+        '.text-white-default': { color: '#FFFFFF' },
+        '.bold24': { fontWeight: '700', fontSize: '24px' },
+        '.bold16': { fontWeight: '700', fontSize: '16px' },
+        '.bold14': { fontWeight: '700', fontSize: '14px' },
+        '.bold12': { fontWeight: '700', fontSize: '12px' },
+        '.medium16': { fontWeight: '500', fontSize: '16px' },
+        '.medium14': { fontWeight: '500', fontSize: '14px' },
+        '.medium12': { fontWeight: '500', fontSize: '12px' }
+      };
+      addComponents(textTheme);
+    },
+    ({ addComponents }) => {
+      const surfaceTheme = {
+        '.surface-default': { background: '#181818' },
+        '.surface-alt': { background: '#202123' },
+        '.surface-point': { background: '#0052F0' },
+        '.surface-point-alt': { background: '#7890E7' },
+        '.surface-disabled': { background: '#AFABAB' },
+        '.surface-content': { background: '#FFFFFF' },
+        '.surface-box': { background: '#ECECEC' },
+        '.surface-box-alt': { background: '#7390B1' },
+      };
+      addComponents(surfaceTheme);
+    },
+    ({ addComponents }) => {
+      const borderTheme = {
+        '.border-default': { border: '1px soild #FFFFFF' },
+        '.border-bold': { border: '1px soild #6E8091' },
+      };
+      addComponents(borderTheme);
+    },
+    ({ addComponents }) => {
+      const shadowTheme = {
+        '.shadow-chat': { boxShadow: '0px 0px 8px 8px rgba(255, 255, 255, 0.10);' },
+        '.shadow-popup': { boxShadow: '0px 4px 4px 0px rgba(0, 0, 0, 0.25)' },
+      };
+      addComponents(shadowTheme);
+    }
+  ],
 };


### PR DESCRIPTION
### 변경 사항
- 피그마의 theme를 tailwindcss에 설정함.

### 고민과 해결 과정

- `text-strong`과 같은 설정들을 theme color가 아니라 plugins로 주어서 text의 색깔을 바로 지정할 수 있게 함.
- theme color로 설정할 시에는 class 명을 `text-text-strong`과 같은 형식으로 주어야 함.
- 마찬가지로 `border-default`는 바로 border color로 `surface-default`는 바로 background 색깔을 지정하게 plugin으로 주었음.

### (선택) 테스트 결과
![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/d18e1ef7-8379-4f8c-a17d-c26bb82ecd8f)

```html
<>
  <div className="w-full h-full bold24 text-weak surface-alt">123132</div>
</>
```
close #86 