### PR TITLE
Fe/feature/#27,133 ai 채팅 화면과 message box 컴포넌트 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,14 +10,13 @@ import ResultSharePage from './pages/ResultSharePage';
 function App() {
   return (
     <>
-      <BackgroundMusic />
       <Routes>
         <Route
           path="/"
           element={<HomePage />}
         />
         <Route
-          path="/chat/ai/:id"
+          path="/chat/ai/:id?"
           element={<AIChatPage />}
         />
         <Route
@@ -33,6 +32,7 @@ function App() {
           element={<ResultSharePage />}
         />
       </Routes>
+      <BackgroundMusic />
     </>
   );
 }

--- a/frontend/src/components/BackgroundMusic/BackgroundMusic.tsx
+++ b/frontend/src/components/BackgroundMusic/BackgroundMusic.tsx
@@ -18,7 +18,7 @@ function BackgroundMusic() {
   };
 
   return (
-    <div className="w-63 h-60 overflow-hidden fixed bottom-10 right-12">
+    <div className="w-63 h-60 overflow-hidden fixed bottom-40 left-48">
       <div className="absolute top-0 left-0">
         <CustomButton
           color={playing ? 'active' : 'disabled'}
@@ -31,7 +31,7 @@ function BackgroundMusic() {
         </CustomButton>
       </div>
       <audio
-        className="opacity-0 absolute -top-5 left-1 h-80"
+        className="opacity-0 absolute -top-20 left-4 h-80"
         loop
         controls
         src={backgroundMusicURL}

--- a/frontend/src/components/CustomButton/CustomButton.tsx
+++ b/frontend/src/components/CustomButton/CustomButton.tsx
@@ -15,7 +15,7 @@ const colorMap: Record<string, string> = {
 };
 
 const sizeMap: Record<string, string> = {
-  s: 'h-40 display-bold14 leading-18 p-12 min-h-0',
+  s: 'h-40 display-bold14 leading-18 p-8 min-h-0',
   m: 'h-50 display-bold16 leading-20 p-16',
   l: 'h-60 display-bold16 leading-30 p-16',
 };

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -7,7 +7,7 @@ interface HeaderProps {
 
 export default function Header({ rightItems }: HeaderProps) {
   return (
-    <div className="flex justify-between items-center surface-content text-default pr-28 pl-28 pt-12 pb-12">
+    <div className="fixed top-0 w-full flex justify-between items-center surface-content text-default px-8 py-5">
       <HeaderLeft />
       <HeaderRight items={rightItems} />
     </div>

--- a/frontend/src/components/Header/HeaderLeft.tsx
+++ b/frontend/src/components/Header/HeaderLeft.tsx
@@ -1,9 +1,17 @@
-import { Link } from "react-router-dom";
+import { Link } from 'react-router-dom';
 
 export default function HeaderLeft() {
   return (
-    <div className="display-bold16">
-      <Link to="/">마법의 소라고둥</Link>
-    </div>
+    <Link
+      to="/"
+      className="flex display-bold16"
+    >
+      <img
+        className="w-33 h-33 mr-8"
+        src="/logo.png"
+        alt="마법의 소라고둥 로고 이미지"
+      />
+      <span className="leading-35 text-strong">마법의 소라고둥</span>
+    </Link>
   );
-};
+}

--- a/frontend/src/components/MessageBox/Message.tsx
+++ b/frontend/src/components/MessageBox/Message.tsx
@@ -1,0 +1,27 @@
+interface MessageProps {
+  type: 'left' | 'right';
+  message: string;
+  profile: string;
+}
+
+const Message = ({ type, message, profile }: MessageProps) => {
+  return (
+    <>
+      <div className={`max-w-600 chat ${type == 'left' ? 'chat-start' : 'chat-end'}`}>
+        <div className="chat-image avatar">
+          <div className="w-60 rounded-full">
+            <img
+              alt="프로필 이미지"
+              src={profile}
+            />
+          </div>
+        </div>
+        <div className={`chat-bubble ${type == 'left' ? 'surface-content text-default' : 'surface-point-alt'}`}>
+          {message}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Message;

--- a/frontend/src/components/MessageBox/MessageBox.tsx
+++ b/frontend/src/components/MessageBox/MessageBox.tsx
@@ -1,0 +1,50 @@
+import { Icon } from '@iconify/react/dist/iconify.js';
+
+import CustomButton from '@components/CustomButton';
+import Message from '@components/MessageBox/Message';
+
+interface MessageBoxProps {
+  tarotId?: string;
+  type: 'left' | 'right';
+  message: string;
+}
+
+// TODO: tarotId로 서버에서 타로 카드 이미지 정보를 받아와서 src와 alt 채워주기
+// TODO: 조건식 !tarotID -> tarotId로 변경
+// TODO: 프로필 이미지 설정
+
+const MessageBox = ({ tarotId, type, message }: MessageBoxProps) => {
+  return (
+    <div className="relative">
+      {!tarotId && type == 'left' && (
+        <img
+          className="w-120 h-200 relative left-72"
+          src="/ddung.png"
+          alt="테스트용 이미지"
+        />
+      )}
+      <div className="flex">
+        <Message
+          type={type}
+          message={message}
+          profile="/moon.png"
+        />
+        {!tarotId && type == 'left' && (
+          <div className="relative right-50 top-105">
+            <CustomButton
+              color="transparent"
+              size="s"
+            >
+              <Icon
+                icon="ion:share"
+                className="text-white text-28"
+              />
+            </CustomButton>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MessageBox;

--- a/frontend/src/components/MessageBox/index.ts
+++ b/frontend/src/components/MessageBox/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MessageBox';

--- a/frontend/src/pages/AIChatPage/AIChatPage.tsx
+++ b/frontend/src/pages/AIChatPage/AIChatPage.tsx
@@ -1,7 +1,33 @@
+import CustomButton from '@/components/CustomButton';
+import Header from '@/components/Header';
+import { Icon } from '@iconify/react/dist/iconify.js';
+
 interface AIChatPageProps {}
 
 const AIChatPage = ({}: AIChatPageProps) => {
-  return <></>;
+  return (
+    <div className="w-screen h-screen">
+      <Header
+        rightItems={[
+          <CustomButton
+            color="transparent"
+            size="s"
+          >
+            <Icon
+              className="w-22 h-22"
+              icon="carbon:side-panel-close"
+            />
+          </CustomButton>,
+        ]}
+      />
+      <img
+        className="absolute w-full h-full object-cover -z-10"
+        src="/bgConch.png"
+        alt="밤 하늘의 배경 이미지"
+      />
+      <div className="w-full h-full bg-black/70" />
+    </div>
+  );
 };
 
 export default AIChatPage;

--- a/frontend/src/pages/AIChatPage/AIChatPage.tsx
+++ b/frontend/src/pages/AIChatPage/AIChatPage.tsx
@@ -1,12 +1,24 @@
 import CustomButton from '@/components/CustomButton';
 import Header from '@/components/Header';
-import { Icon } from '@iconify/react/dist/iconify.js';
+import MessageBox from '@/components/MessageBox/MessageBox';
+import { Icon } from '@iconify/react';
 
 interface AIChatPageProps {}
 
 const AIChatPage = ({}: AIChatPageProps) => {
   return (
-    <div className="w-screen h-screen">
+    <div className="w-screen h-screen flex flex-col justify-center items-center gap-80">
+      <img
+        className="absolute w-full h-full object-cover -z-10"
+        src="/bg.png"
+        alt="밤 하늘의 배경 이미지"
+      />
+      <img
+        className="w-285 h-285 relative bottom-130"
+        src="/moon.png"
+        alt="빛나는 마법의 소라 고둥"
+      />
+      <div className="absolute w-full h-full bg-black/80 animate-fadeIn" />
       <Header
         rightItems={[
           <CustomButton
@@ -21,12 +33,6 @@ const AIChatPage = ({}: AIChatPageProps) => {
           </CustomButton>,
         ]}
       />
-      <img
-        className="absolute w-full h-full object-cover -z-10"
-        src="/bgConch.png"
-        alt="밤 하늘의 배경 이미지"
-      />
-      <div className="w-full h-full bg-black/70" />
     </div>
   );
 };

--- a/frontend/src/pages/AIChatPage/AIChatPage.tsx
+++ b/frontend/src/pages/AIChatPage/AIChatPage.tsx
@@ -12,6 +12,7 @@ const AIChatPage = ({}: AIChatPageProps) => {
           <CustomButton
             color="transparent"
             size="s"
+            key="side-panel-close"
           >
             <Icon
               className="w-22 h-22"

--- a/frontend/src/pages/AIChatPage/AIChatPage.tsx
+++ b/frontend/src/pages/AIChatPage/AIChatPage.tsx
@@ -1,9 +1,12 @@
 import CustomButton from '@/components/CustomButton';
 import Header from '@/components/Header';
-import MessageBox from '@/components/MessageBox/MessageBox';
+import MessageBox from '@/components/MessageBox';
 import { Icon } from '@iconify/react';
 
 interface AIChatPageProps {}
+
+const messageTest =
+  "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. ";
 
 const AIChatPage = ({}: AIChatPageProps) => {
   return (
@@ -14,11 +17,11 @@ const AIChatPage = ({}: AIChatPageProps) => {
         alt="밤 하늘의 배경 이미지"
       />
       <img
-        className="w-285 h-285 relative bottom-130"
+        className="w-285 h-285 animate-shining relative bottom-130"
         src="/moon.png"
         alt="빛나는 마법의 소라 고둥"
       />
-      <div className="absolute w-full h-full bg-black/80 animate-fadeIn" />
+      <div className="absolute w-full h-full bg-black/75 animate-fadeIn" />
       <Header
         rightItems={[
           <CustomButton
@@ -33,6 +36,22 @@ const AIChatPage = ({}: AIChatPageProps) => {
           </CustomButton>,
         ]}
       />
+
+      {/* 테스트용 임시 ul */}
+      <ul className="absolute w-800 m-auto">
+        <li>
+          <MessageBox
+            type="left"
+            message={messageTest}
+          />
+        </li>
+        <li>
+          <MessageBox
+            type="right"
+            message={messageTest}
+          />
+        </li>
+      </ul>
     </div>
   );
 };

--- a/frontend/src/pages/HomePage/HomePage.tsx
+++ b/frontend/src/pages/HomePage/HomePage.tsx
@@ -13,7 +13,7 @@ const HomePage = () => {
         alt="밤 하늘의 배경 이미지"
       />
       <img
-        className="w-214 h-214 animate-shining"
+        className="w-285 h-285 animate-shining"
         src="/moon.png"
         alt="빛나는 마법의 소라 고둥"
       />

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -19,14 +19,20 @@ export default {
       margin: px0_2000,
       lineHeight: px0_100,
       fontSize: px0_100,
+      inset: px0_2000,
       keyframes: {
         shining: {
           '0%': { filter: 'drop-shadow(0px 0px 25px rgba(255, 255, 255, 0.8))' },
           '100%': { filter: 'drop-shadow(0px 0px 50px rgba(255, 255, 255, 0.8))' },
         },
+        fadeIn: {
+          '0%': { opacity: 0 },
+          '100%': { opacity: 1 },
+        },
       },
       animation: {
         shining: 'shining 2s ease-in-out infinite alternate',
+        fadeIn: 'fadeIn 1.5s ease-in-out',
       },
     },
   },


### PR DESCRIPTION
resolve #27
resolve #133 

### 변경 사항
- message 컴포넌트 구현
- messageBox 컴포넌트 구현
- 라우터 파라미터 id를 필수값이 아닌 선택값으로 변경
- 헤더 수정
- 뮤직 버튼 위치 수정
- tailwind 설정 추가
- 어두운 밑 배경과 fadein 애니메이션 적용

<br>

### 고민
- 배경 이미지 부분이 계속 반복되는 거 같은데 묶어서 하나의 컴포넌트로 만들어보는게 좋을까?
```
   <div className="w-screen h-screen flex flex-col justify-center items-center gap-80">
      <img
        className="absolute w-full h-full object-cover -z-10"
        src="/bg.png"
        alt="밤 하늘의 배경 이미지"
      />
      <img
        className="w-285 h-285 animate-shining relative bottom-130"
        src="/moon.png"
        alt="빛나는 마법의 소라 고둥"
      />
      <div className="absolute w-full h-full bg-black/75 animate-fadeIn" />
```


<br>

### 테스트 결과

https://github.com/boostcampwm2023/web09-MagicConch/assets/69742775/6ddecd41-a4f6-4377-baf5-a0fd4f4e9077


