### PR TITLE
Be/feature/#143 타로 api 및 서비스 구현

### DIFF
--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -8,11 +8,12 @@ import {
   Patch,
   Post,
   Req,
-  UnauthorizedException,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiBody,
   ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
@@ -20,12 +21,14 @@ import {
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { Request } from 'express';
+import { AuthGuard } from 'src/common/auth/auth.guard';
 import { ChatService } from './chat.service';
 import { ChattingMessageResponseDto } from './dto/chatting-messag-response.dto';
 import { ChattingRoomResponseDto } from './dto/chatting-room-response.dto';
 import { CreateChattingMessageDto } from './dto/create-chatting-message.dto';
 import { UpdateChattingRoomDto } from './dto/update-chatting-room.dto';
 
+@UseGuards(AuthGuard)
 @Controller('chat')
 @ApiTags('✅Chatting API')
 export class ChatController {
@@ -39,9 +42,6 @@ export class ChatController {
   })
   @ApiUnauthorizedResponse({ description: '인증 받지 않은 사용자' })
   async findRooms(@Req() req: Request): Promise<ChattingRoomResponseDto[]> {
-    if (!req.cookies.magicConch) {
-      throw new UnauthorizedException();
-    }
     return await this.chatService.findRoomsById(req.cookies.magicConch);
   }
 
@@ -55,11 +55,7 @@ export class ChatController {
   @ApiUnauthorizedResponse({ description: '인증 받지 않은 사용자' })
   async findMessages(
     @Param('id', ParseUUIDPipe) id: string,
-    @Req() req: Request,
   ): Promise<ChattingMessageResponseDto[]> {
-    if (!req.cookies.magicConch) {
-      throw new UnauthorizedException();
-    }
     return await this.chatService.findMessagesById(id);
   }
 
@@ -73,11 +69,7 @@ export class ChatController {
   async createMessages(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() CreateChattingMessageDto: CreateChattingMessageDto[],
-    @Req() req: Request,
   ): Promise<void> {
-    if (!req.cookies.magicConch) {
-      throw new UnauthorizedException();
-    }
     return await this.chatService.createMessage(id, CreateChattingMessageDto);
   }
 
@@ -86,8 +78,9 @@ export class ChatController {
   @ApiParam({ type: 'uuid', name: 'id' })
   @ApiBody({ type: UpdateChattingRoomDto })
   @ApiOkResponse({ description: '채팅방 제목 수정 성공' })
+  @ApiNotFoundResponse({ description: '존재하지 않는 채팅방 ID' })
   @ApiInternalServerErrorResponse()
-  async update(
+  async updateRoom(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateChattingRoomDto: UpdateChattingRoomDto,
   ): Promise<void> {
@@ -99,7 +92,7 @@ export class ChatController {
   @ApiParam({ type: 'uuid', name: 'id' })
   @ApiOkResponse({ description: '채팅방 삭제 성공' })
   @ApiInternalServerErrorResponse()
-  async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+  async removeRoom(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
     await this.chatService.removeRoom(id);
   }
 }

--- a/backend/src/common/auth/auth.guard.ts
+++ b/backend/src/common/auth/auth.guard.ts
@@ -1,0 +1,21 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const req: Request = context.switchToHttp().getRequest();
+    if (!req.cookies.magicConch) {
+      throw new UnauthorizedException();
+    }
+    return true;
+  }
+}

--- a/backend/src/common/config/database/database.module.ts
+++ b/backend/src/common/config/database/database.module.ts
@@ -10,11 +10,11 @@ import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
       useFactory: (configService: ConfigService) => {
         return {
           type: 'mysql',
-          host: configService.get('db_host'),
-          port: configService.get<number>('db_port'),
-          username: configService.get('db_username'),
-          password: configService.get('db_password'),
-          database: configService.get('db_database'),
+          host: configService.get('DB_HOST'),
+          port: configService.get<number>('DB_PORT'),
+          username: configService.get('DB_USERNAME'),
+          password: configService.get('DB_PASSWORD'),
+          database: configService.get('DB_DATABASE'),
           entities: [],
           synchronize: true,
           autoLoadEntities: true,

--- a/backend/src/tarot/dto/create-tarot-result.dto.ts
+++ b/backend/src/tarot/dto/create-tarot-result.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsUrl } from 'class-validator';
+
+export class CreateTarotResultDto {
+  /**
+   * TODO : 추후 변동 가능성 있음
+   */
+  @IsUrl()
+  @ApiProperty({ description: '타로 카드 URL', required: true })
+  cardUrl: string;
+
+  @IsString()
+  @ApiProperty({ description: '타로 해설 결과', required: true })
+  message: string;
+}

--- a/backend/src/tarot/dto/tarot-card-response.dto.ts
+++ b/backend/src/tarot/dto/tarot-card-response.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUrl } from 'class-validator';
+
+export class TarotCardResponseDto {
+  @IsUrl()
+  @ApiProperty({ description: '타로 카드 이미지 URL', required: true })
+  cardUrl: string;
+}

--- a/backend/src/tarot/dto/tarot-result-response.dto.ts
+++ b/backend/src/tarot/dto/tarot-result-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsUrl } from 'class-validator';
+
+export class TarotResultResponseDto {
+  @IsUrl()
+  @ApiProperty({ description: '타로 카드 이미지 URL', required: true })
+  cardUrl: string;
+
+  @IsString()
+  @ApiProperty({ description: '타로 해설 결과', required: true })
+  message: string;
+}

--- a/backend/src/tarot/entities/tarot-card.entity.ts
+++ b/backend/src/tarot/entities/tarot-card.entity.ts
@@ -16,6 +16,10 @@ export class TarotCard {
   @Column('int')
   cardNo: number;
 
+  /**
+   * TODO : 추후 개선 사항
+   * cardPack은 사용자가 지정한 타로 카드팩 이름
+   */
   @Column({ length: 20 })
   cardPack: string;
 

--- a/backend/src/tarot/entities/tarot-result.entity.ts
+++ b/backend/src/tarot/entities/tarot-result.entity.ts
@@ -11,8 +11,11 @@ export class TarotResult {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ type: 'binary', length: 32 })
-  tarotResult: string;
+  @Column({ length: 255 })
+  cardUrl: string;
+
+  @Column({ type: 'text' })
+  message: string;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/backend/src/tarot/tarot.controller.ts
+++ b/backend/src/tarot/tarot.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import {
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+import { TarotCardResponseDto } from './dto/tarot-card-response.dto';
+import { TarotResultResponseDto } from './dto/tarot-result-response.dto';
+import { TarotService } from './tarot.service';
+
+@Controller('tarot')
+@ApiTags('✅ Tarot API')
+export class TarotController {
+  constructor(private readonly tarotService: TarotService) {}
+
+  @Get('card/:id')
+  @ApiOperation({ summary: '타로 카드 이미지 URL 조회 API' })
+  @ApiParam({ type: 'integer', name: 'id' })
+  @ApiOkResponse({
+    description: '타로 카드 이미지 URL 조회 성공',
+    type: TarotCardResponseDto,
+  })
+  @ApiNotFoundResponse({ description: '존재하지 않는 카드' })
+  @ApiInternalServerErrorResponse()
+  async findTarotCardById(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<TarotCardResponseDto> {
+    return await this.tarotService.findTarotCardById(id);
+  }
+
+  @Get('result/:id')
+  @ApiOperation({ summary: '타로 결과 조회 API' })
+  @ApiParam({ type: 'uuid', name: 'id' })
+  @ApiOkResponse({
+    description: '타로 결과 조회 성공',
+    type: TarotResultResponseDto,
+  })
+  @ApiNotFoundResponse({ description: '존재하지 않는 타로 결과' })
+  @ApiInternalServerErrorResponse()
+  async findTarotResultById(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<TarotResultResponseDto> {
+    return await this.tarotService.findTarotResultById(id);
+  }
+}

--- a/backend/src/tarot/tarot.module.ts
+++ b/backend/src/tarot/tarot.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TarotCard } from './entities/tarot-card.entity';
+import { TarotResult } from './entities/tarot-result.entity';
+import { TarotController } from './tarot.controller';
+import { TarotService } from './tarot.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TarotCard, TarotResult])],
+  controllers: [TarotController],
+  providers: [TarotService],
+})
+export class TarotModule {}

--- a/backend/src/tarot/tarot.service.ts
+++ b/backend/src/tarot/tarot.service.ts
@@ -1,0 +1,66 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreateTarotResultDto } from './dto/create-tarot-result.dto';
+import { TarotCardResponseDto } from './dto/tarot-card-response.dto';
+import { TarotResultResponseDto } from './dto/tarot-result-response.dto';
+import { TarotCard } from './entities/tarot-card.entity';
+import { TarotResult } from './entities/tarot-result.entity';
+
+@Injectable()
+export class TarotService {
+  constructor(
+    @InjectRepository(TarotCard)
+    private readonly tarotCardRepository: Repository<TarotCard>,
+    @InjectRepository(TarotResult)
+    private readonly tarotResultRepository: Repository<TarotResult>,
+  ) {}
+
+  /**
+   * TODO
+   * 추후 Object Storage 도입으로 DTO 변동 가능성 있음
+   */
+  async createTarotResult(
+    createTarotResultDto: CreateTarotResultDto,
+  ): Promise<void> {
+    const tarotResult: TarotResult = new TarotResult();
+    tarotResult.cardUrl = createTarotResultDto.cardUrl;
+    tarotResult.message = createTarotResultDto.message;
+    try {
+      this.tarotResultRepository.save(tarotResult);
+    } catch (err: unknown) {
+      throw err;
+    }
+  }
+
+  /**
+   * TODO
+   * 추후 Object Storage에 접근하는 로직으로 변경
+   * 타로 카드팩이 커스텀이 가능한 경우, 전체적인 로직 수정 필요
+   */
+  async findTarotCardById(id: number): Promise<TarotCardResponseDto> {
+    const tarotCard: TarotCard | null =
+      await this.tarotCardRepository.findOneBy({
+        cardNo: id,
+        owner: undefined,
+      });
+    if (!tarotCard) {
+      throw new NotFoundException();
+    }
+    const cardDto = new TarotCardResponseDto();
+    cardDto.cardUrl = tarotCard.cardUrl;
+    return cardDto;
+  }
+
+  async findTarotResultById(id: string): Promise<TarotResultResponseDto> {
+    const tarotResult: TarotResult | null =
+      await this.tarotResultRepository.findOneBy({ id });
+    if (!tarotResult) {
+      throw new NotFoundException();
+    }
+    const resultDto = new TarotResultResponseDto();
+    resultDto.cardUrl = tarotResult.cardUrl;
+    resultDto.message = tarotResult.message;
+    return resultDto;
+  }
+}


### PR DESCRIPTION
### 변경 사항
타로 관련 API 및 서비스 작성
아직 ObjectStorage와 클로바 스튜디오를 연결하지 않아 수정될 가능성이 높다.

**컨트롤러** 
- `GET /tarot/card/:id` : 카드 숫자가 id인 카드 이미지를 반환한다.
- `GET /tarot/result/:id` : 해당 ID의 타로 결과를 반환한다.

**서비스**
- `findTarotCardById` : 카드 번호가 id인 카드 이미지 URL을 반환한다.
- `createTarotResult` : 웹소켓에서 호출하게 되는 메서드로, 클로바 API 호출 후 그 결과를 `message`에 저장한다.
- `findTarotResultById` : 해당 ID의 타로 결과를 반환한다.

### 고민과 해결 과정

어제 작업물에서 `req` 객체에 쿠키가 붙어있는지 확인하는 코드가 중복으로 사용되는 게 마음에 걸려 해당 부분을 가드를 사용하여 수정했다.

```ts
...
@Injectable()
export class AuthGuard implements CanActivate {
  canActivate(
    context: ExecutionContext,
  ): boolean | Promise<boolean> | Observable<boolean> {
    const req: Request = context.switchToHttp().getRequest();
    if (!req.cookies.magicConch) { // AuthGuard에서 쿠키 여부 확인 -> 쿠키 없으면 UnauthorizedException 던짐
      throw new UnauthorizedException();
    }
    return true; // 쿠키 있으므로 인증한 사용자
  }
}
```

위의 가드를 작성한 후, 채팅 컨트롤러에 `@UseGuard` 데코레이터만 붙여주면 컨트롤러 단에서 쿠키가 있는지 검사하므로 각 메서드 내에서 쿠키를 검증할 필요가 없다.


### (선택) 테스트 결과