### PR TITLE
Be/feature/#143 타로 api 및 서비스 구현

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,12 +1,34 @@
-import { Controller, Get } from '@nestjs/common';
-import { AppService } from './app.service';
+import { Controller, Get, Req, Res } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Request, Response } from 'express';
+import { Member } from './members/entities/member.entity';
+import { MembersService } from './members/members.service';
 
 @Controller()
+@ApiTags('✅Main API')
 export class AppController {
-  constructor(private readonly appService: AppService) {}
+  constructor(private readonly membersService: MembersService) {}
 
   @Get()
-  getHello(): string {
-    return this.appService.getHello();
+  @ApiOperation({ summary: '메인 페이지 접속' })
+  @ApiOkResponse({
+    description:
+      '7일간 접속 이력이 없는 사용자는 새롭게 레코드 생성 후 쿠키 부착',
+  })
+  async startPage(@Req() req: Request, @Res() res: Response): Promise<any> {
+    const magicConch: string | undefined = req.cookies.magicConch;
+    if (magicConch) {
+      res.cookie('magicConch', magicConch, {
+        httpOnly: true,
+        maxAge: 7 * 24 * 60 * 60 * 1000,
+      });
+      return res.sendStatus(200);
+    }
+    const member: Member = await this.membersService.create();
+    res.cookie('magicConch', member.id, {
+      httpOnly: true,
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+    });
+    return res.sendStatus(200);
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,11 +1,27 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config/dist';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { ChatModule } from './chat/chat.module';
+import { DatabaseModule } from './common/config/database/database.module';
 import { EventsModule } from './events/events.module';
+import { Member } from './members/entities/member.entity';
+import { MembersModule } from './members/members.module';
+import { MembersService } from './members/members.service';
+import { TarotModule } from './tarot/tarot.module';
 
 @Module({
-  imports: [EventsModule],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    MembersModule,
+    DatabaseModule,
+    ChatModule,
+    TarotModule,
+    TypeOrmModule.forFeature([Member]),
+    TarotModule,
+    EventsModule,
+  ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [MembersService],
 })
 export class AppModule {}

--- a/backend/src/members/entities/member.entity.ts
+++ b/backend/src/members/entities/member.entity.ts
@@ -1,5 +1,5 @@
 import { ChattingRoom } from 'src/chat/entities/chatting-room.entity';
-import { TarotCard } from 'src/tarot/entities/tarot-card.entity';
+import { TarotCardPack } from 'src/tarot/entities/tarot-card-pack.entity';
 import {
   Column,
   CreateDateColumn,
@@ -32,6 +32,6 @@ export class Member {
   @OneToMany(() => ChattingRoom, (chattingRoom) => chattingRoom.participant)
   chattingRooms: ChattingRoom[];
 
-  @OneToMany(() => TarotCard, (tarotCard) => tarotCard.owner)
-  tarotCards: TarotCard[];
+  @OneToMany(() => TarotCardPack, (tarotCardPack) => tarotCardPack.owner)
+  tarotCardPacks: TarotCardPack[];
 }

--- a/backend/src/tarot/entities/tarot-card-pack.entity.ts
+++ b/backend/src/tarot/entities/tarot-card-pack.entity.ts
@@ -1,0 +1,39 @@
+import { Member } from 'src/members/entities/member.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { TarotCard } from './tarot-card.entity';
+
+/**
+ * TODO : 추후 개선 사항
+ * 사용자별 카드 위치 : objectUrl/memberId/cardPackId/cardNo
+ */
+@Entity()
+export class TarotCardPack {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ length: 20 })
+  cardPackName: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @Column({ nullable: true })
+  deletedAt: Date;
+
+  @ManyToOne(() => Member, (member) => member.tarotCardPacks)
+  owner: Member;
+
+  @OneToMany(() => TarotCard, (tarotCard) => tarotCard.cardPack)
+  tarotCards: TarotCard[];
+}

--- a/backend/src/tarot/entities/tarot-card.entity.ts
+++ b/backend/src/tarot/entities/tarot-card.entity.ts
@@ -16,6 +16,9 @@ export class TarotCard {
   @Column('int')
   cardNo: number;
 
+  @Column({ length: 10 })
+  ext: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/src/tarot/entities/tarot-card.entity.ts
+++ b/backend/src/tarot/entities/tarot-card.entity.ts
@@ -1,4 +1,3 @@
-import { Member } from 'src/members/entities/member.entity';
 import {
   Column,
   CreateDateColumn,
@@ -7,6 +6,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { TarotCardPack } from './tarot-card-pack.entity';
 
 @Entity()
 export class TarotCard {
@@ -15,16 +15,6 @@ export class TarotCard {
 
   @Column('int')
   cardNo: number;
-
-  /**
-   * TODO : 추후 개선 사항
-   * cardPack은 사용자가 지정한 타로 카드팩 이름
-   */
-  @Column({ length: 20 })
-  cardPack: string;
-
-  @Column({ length: 255 })
-  cardUrl: string;
 
   @CreateDateColumn()
   createdAt: Date;
@@ -35,6 +25,6 @@ export class TarotCard {
   @Column({ nullable: true })
   deletedAt: Date;
 
-  @ManyToOne(() => Member, (member) => member.tarotCards)
-  owner: Member;
+  @ManyToOne(() => TarotCardPack, (tarotCardPack) => tarotCardPack.tarotCards)
+  cardPack: TarotCardPack;
 }

--- a/backend/src/tarot/tarot.module.ts
+++ b/backend/src/tarot/tarot.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { TarotCardPack } from './entities/tarot-card-pack.entity';
 import { TarotCard } from './entities/tarot-card.entity';
 import { TarotResult } from './entities/tarot-result.entity';
 import { TarotController } from './tarot.controller';
 import { TarotService } from './tarot.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([TarotCard, TarotResult])],
+  imports: [TypeOrmModule.forFeature([TarotCard, TarotResult, TarotCardPack])],
   controllers: [TarotController],
   providers: [TarotService],
 })

--- a/backend/src/tarot/tarot.service.ts
+++ b/backend/src/tarot/tarot.service.ts
@@ -7,7 +7,7 @@ import { TarotResultResponseDto } from './dto/tarot-result-response.dto';
 import { TarotCard } from './entities/tarot-card.entity';
 import { TarotResult } from './entities/tarot-result.entity';
 
-const objectStorageUrl = 'https://kr.object.ncloudstorage.com/magicconch';
+const bucketUrl = 'https://kr.object.ncloudstorage.com/magicconch';
 
 @Injectable()
 export class TarotService {
@@ -44,7 +44,7 @@ export class TarotService {
       throw new NotFoundException();
     }
     const cardDto = new TarotCardResponseDto();
-    const url: string = `${objectStorageUrl}/basic/${id}.jpg`;
+    const url: string = `${bucketUrl}/basic/${id}${tarotCard.ext}`;
     cardDto.cardUrl = url;
     return cardDto;
   }

--- a/backend/src/tarot/tarot.service.ts
+++ b/backend/src/tarot/tarot.service.ts
@@ -7,6 +7,8 @@ import { TarotResultResponseDto } from './dto/tarot-result-response.dto';
 import { TarotCard } from './entities/tarot-card.entity';
 import { TarotResult } from './entities/tarot-result.entity';
 
+const objectStorageUrl = 'https://kr.object.ncloudstorage.com/magicconch';
+
 @Injectable()
 export class TarotService {
   constructor(
@@ -16,10 +18,6 @@ export class TarotService {
     private readonly tarotResultRepository: Repository<TarotResult>,
   ) {}
 
-  /**
-   * TODO
-   * 추후 Object Storage 도입으로 DTO 변동 가능성 있음
-   */
   async createTarotResult(
     createTarotResultDto: CreateTarotResultDto,
   ): Promise<void> {
@@ -34,21 +32,20 @@ export class TarotService {
   }
 
   /**
-   * TODO
-   * 추후 Object Storage에 접근하는 로직으로 변경
-   * 타로 카드팩이 커스텀이 가능한 경우, 전체적인 로직 수정 필요
+   * TODO : 추후 타로 카드팩이 커스텀이 가능한 경우, 전체적인 로직 수정 필요
    */
   async findTarotCardById(id: number): Promise<TarotCardResponseDto> {
     const tarotCard: TarotCard | null =
       await this.tarotCardRepository.findOneBy({
         cardNo: id,
-        owner: undefined,
+        cardPack: undefined,
       });
     if (!tarotCard) {
       throw new NotFoundException();
     }
     const cardDto = new TarotCardResponseDto();
-    cardDto.cardUrl = tarotCard.cardUrl;
+    const url: string = `${objectStorageUrl}/basic/${id}.jpg`;
+    cardDto.cardUrl = url;
     return cardDto;
   }
 


### PR DESCRIPTION
### 변경 사항
서비스 확장을 고려하여 타로 관련 entity를 수정했다. 
사용자가 자신만의 타로 카드팩을 업로드 하는 것이 가능하므로 타로 카드팩이라는 entity를 생성했다.
```ts
...
@Entity()
export class TarotCardPack {
  @PrimaryGeneratedColumn('uuid')
  id: string;

  @Column({ length: 20 })
  cardPackName: string; // 카드팩 별칭
  ...
  @ManyToOne(() => Member, (member) => member.tarotCardPacks) // memberId를 FK로 가짐
  owner: Member;

  @OneToMany(() => TarotCard, (tarotCard) => tarotCard.cardPack) // 카드팩에는 여러 카드들이 속함
  tarotCards: TarotCard[];
}
``` 

```ts
...
@Entity()
export class TarotCard {
  @PrimaryGeneratedColumn('uuid')
  id: string;

  @Column('int')
  cardNo: number; // 타로 카드 번호 (ex. 0번 카드 == Fool) 
  ...
  @ManyToOne(() => TarotCardPack, (tarotCardPack) => tarotCardPack.tarotCards) // cardPackId를 FK로 가짐 
  cardPack: TarotCardPack;
}
```

### 고민과 해결 과정

추후 서비스 확장 시, 특정 타로 카드에 대한 ObjectStorage URL을 다음과 같이 설정할 예정이다.
```ts
// 타로 카드팩의 ID 가 UUID이므로 타로 카드팩은 고유한 디렉토리명을 가짐
const cardUrl = `${bucketUrl}/${tarotCardPackID}/${tarotCardNo}${fileExt}`;
``` 
서비스를 확장하게 되면 다음 사항들을 고려해야 할 것 같다.
- 사진 파일만 올릴 수 있도록 확장자 제한 필요
- 타로 카드가 맞는지 확인하는 AI 모델 필요

### (선택) 테스트 결과