### PR TITLE
Be/feature/#191 docker 배포 자동화

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+*node_modules/
+*dist/
+
+*nest-cli.json
+*tsconfig.build.json
+*tsconfig.json
+
+*.git
+*.gitignore

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -1,0 +1,45 @@
+name: Dockerized CD
+
+on:
+  push:
+    branches: ["dev"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker Images
+        run: docker-compose build
+
+      - name: Push Docker Images to Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      - run: docker-compose push
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Run Docker on Remote Server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          port: ${{ secrets.SSH_PORT }}
+          script: |
+            docker-compose -f ~/web09-MagicConch/docker-compose.yml pull
+            docker-compose -f ~/web09-MagicConch/docker-compose.yml up -d

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -12,6 +12,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Generate .env file
+        run: |
+          echo "DB_PORT=${{ secrets.DB_PORT }}" > .env
+          echo "DB_HOST=${{ secrets.DB_HOST }}" >> .env
+          echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> .env
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+          echo "DB_DATABASE=${{ secrets.DB_DATABASE }}" >> .env
+          echo "ACCESS_KEY_ID=${{ secrets.ACCESS_KEY_ID }}" >> .env
+          echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> .env
+          echo "X_NCP_CLOVASTUDIO_API_KEY=${{ secrets.X_NCP_CLOVASTUDIO_API_KEY }}" >> .env
+          echo "X_NCP_APIGW_API_KEY=${{ secrets.X_NCP_APIGW_API_KEY }}" >> .env
+
+      - name: Copy .env to Remote Server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          port: ${{ secrets.SSH_PORT }}
+          source: ".env"
+          target: "~/app"
+
       - name: Build Docker Images
         run: docker-compose build
 
@@ -41,5 +63,7 @@ jobs:
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
           script: |
-            docker-compose -f ~/web09-MagicConch/docker-compose.yml pull
-            docker-compose -f ~/web09-MagicConch/docker-compose.yml up -d
+            cd ~/app
+            git pull origin dev
+            docker-compose pull
+            docker-compose up -d

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,0 +1,7 @@
+FROM nginx:1.18.0
+
+COPY config/nginx/default.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -3,7 +3,6 @@ FROM node:20
 WORKDIR /app
 
 COPY backend .
-COPY backend/package*.json ./
 
 RUN npm install
 RUN npm run build

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,0 +1,11 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY backend .
+COPY backend/package*.json ./
+
+RUN npm install
+RUN npm run build
+
+CMD ["npm", "run", "start:prod"]

--- a/config/nginx/default.conf
+++ b/config/nginx/default.conf
@@ -1,11 +1,11 @@
 upstream nest {
-    server 127.0.0.1:3000;
+    server node:3000;
 }
 
 server {
 	listen 80;
-
-    location / {
+	
+	location / {
 	    proxy_pass http://nest;
 	    proxy_http_version 1.1;
 	    proxy_set_header Upgrade $http_upgrade;
@@ -13,7 +13,7 @@ server {
 	    proxy_set_header Host $host;
 	    proxy_cache_bypass $http_upgrade;
 	}
-
-    access_log /var/log/nginx/nest-app-access.log;
+	
+	access_log /var/log/nginx/nest-app-access.log;
 	error_log /var/log/nginx/nest-app-error.log;
 }

--- a/config/nginx/default.conf
+++ b/config/nginx/default.conf
@@ -1,0 +1,19 @@
+upstream nest {
+    server 127.0.0.1:3000;
+}
+
+server {
+	listen 80;
+
+    location / {
+	    proxy_pass http://nest;
+	    proxy_http_version 1.1;
+	    proxy_set_header Upgrade $http_upgrade;
+	    proxy_set_header Connection 'upgrade';
+	    proxy_set_header Host $host;
+	    proxy_cache_bypass $http_upgrade;
+	}
+
+    access_log /var/log/nginx/nest-app-access.log;
+	error_log /var/log/nginx/nest-app-error.log;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.3"
+
+services:
+  node:
+    build:
+      context: .
+      dockerfile: Dockerfile.node
+    environment:
+      - DB_PORT=${DB_PORT}
+      - DB_HOST=${DB_HOST}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_DATABASE=${DB_DATABASE}
+      - ACCESS_KEY_ID=${ACCESS_KEY_ID}
+      - SECRET_KEY=${SECRET_KEY}
+      - X_NCP_CLOVASTUDIO_API_KEY=${X_NCP_CLOVASTUDIO_API_KEY}
+      - X_NCP_APIGW_API_KEY=${X_NCP_APIGW_API_KEY}
+    extra_hosts:
+      - "host.docker.internal:172.17.0.1"
+    expose:
+      - 3000
+
+  nginx:
+    build:
+      context: .
+      dockerfile: Dockerfile.nginx
+    ports:
+      - "8080:80"
+    depends_on:
+      - node


### PR DESCRIPTION
### 변경 사항
GitHub Actions로 docker CD 자동화 구현하기
(nginx와 node 이미지를 따로 띄우기 위해 docker-compose를 사용했다)

[[타로밀크티 기술 블로그] GitHub Actions로 CI/CD 자동화하기](https://www.notion.so/GitHub-Actions-CI-CD-6c607b37cea24e5db0b20a39e30df154)

### 고민과 해결 과정

**1️⃣ 502 Bad Gateway,,,**

`docker-compose.yml` 에 따라 node와 nest 컨테이너가 실행된다. 하지만 `http://sever_ip:8080` 으로 접속한 결과, `502 Bad Gateway`를 띄웠다.

**2️⃣ nest 어플리케이션이 동작하지 않는다,,,**

`502 Bad Gateway`가 떴다는 것은 nginx가 잘 동작하고 있음을 의미하므로 nest 어플리케이션 실행을 확인하기 위해 다음 커맨드를 실행했다.

```bash
curl http://localhost:3000
Failed to connect to localhost port 3000: Connection refused
```

**3️⃣ 도커 컨테이너를 확인해보자,,,**

Docker Compose로 띄운 컨테이너 중 node 컨테이너에서 다음과 같은 오류가 발생했다. `cd6024be7c28` 는 `docker ps -a` 로 조회한 node 컨테이너 ID다.

```bash
docker logs cd6024be7c28

> backend@0.0.1 start:prod
> node dist/main

[Nest] 19  - 11/20/2023, 8:58:38 AM     LOG [NestFactory] Starting Nest application...
...
[TypeOrmModule] Unable to connect to the database. Retrying (1)...
Error: connect ECONNREFUSED 127.0.0.1:3306
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
```

**4️⃣ nest 어플리케이션이 mysql에 접근하지 못한다,,,**

도커 로그를 통해 nest 어플리케이션이 mysql에 접속하지 못한다는 걸 알 수 있었다. 호스트에서 직접 `npm run start:prod` 를 했을 때는 오류가 발생하지 않는데 도커 컨테이너로 실행할 때만 위의 에러가 발생했다.

도커 컨테이너는 호스트와 다른 IP 주소를 갖는다. 즉, 도커로 nest 어플리케이션을 구동하여 `127.0.0.1:3306` 에 접속하면, 도커 컨테이너 내부의 3306번 포트에 어떠한 프로그램도 실행되고 있지 않기 때문에 해당 에러가 발생한다.
![ifconfig_screenshot](https://github.com/boostcampwm2023/web09-MagicConch/assets/70785620/c2e6c3d4-d541-4ea8-981f-e24a3be597c5)


도커 컨테이너에서 호스트의 포트로 접근하기 위해서는 `host.docker.internal` 이라는 도메인 네임을 사용해야 한다. 따라서 `docker-compose.yml`에 아래 코드를 추가하여 에러를 해결했다.
```yaml
extra_hosts:
      - "host.docker.internal:172.17.0.1"
```

### (선택) 테스트 결과
`http://223.130.163.10:8080/api`를 실행하면 서버 접속가능
![success_screenshot](https://github.com/boostcampwm2023/web09-MagicConch/assets/70785620/2721445f-48a1-4447-9e2f-f37afc3b9a49)

