### PR TITLE
Fe,be/feature/#169 #181 타로 해설 이후에 피드백 요구 told 도입

### DIFF
--- a/backend/src/events/constants.ts
+++ b/backend/src/events/constants.ts
@@ -1,3 +1,5 @@
+import exp from 'constants';
+
 export {
   X_NCP_APIGW_API_KEY,
   X_NCP_CLOVASTUDIO_API_KEY,
@@ -5,6 +7,11 @@ export {
 
 export const CLOVA_URL =
   'https://clovastudio.stream.ntruss.com/testapp/v1/chat-completions/HCX-002';
+
+export const askTarotCardMessage = '타로 카드를 뽑아볼까?';
+
+export const chatEndMessage =
+  '이번 상담은 어땠어?\n피드백을 남겨주면 내가 더 발전할 수 있어!';
 
 export const tarotReadingSystemMessage = `
 사용자가 말한 고민에 대해 공감성 멘트로 친근한 반말로 타로 카드를 해설하시오.
@@ -28,8 +35,6 @@ export const tarotReadingSystemMessage = `
 
 이별이라는 불안한 생각보다는 앞으로의 관계를 더 좋게 만들어갈 수 있다고 믿어봐. 물론 쉽지 않겠지만, 조금씩 노력하면 분명 좋은 결과가 있을 거야.
 ###`;
-
-export const askTarotCardMessage = '타로 카드를 뽑아볼까?';
 
 export const talkSystemMessage = `
 user는 타로 상담을 하러 온 사람이고, assistant는 타로 상담을 하는 사람이다.

--- a/backend/src/events/constants.ts
+++ b/backend/src/events/constants.ts
@@ -29,7 +29,7 @@ export const tarotReadingSystemMessage = `
 이별이라는 불안한 생각보다는 앞으로의 관계를 더 좋게 만들어갈 수 있다고 믿어봐. 물론 쉽지 않겠지만, 조금씩 노력하면 분명 좋은 결과가 있을 거야.
 ###`;
 
-export const askTarotCardMessage = '그럼 타로 카드를 뽑아볼까?';
+export const askTarotCardMessage = '타로 카드를 뽑아볼까?';
 
 export const talkSystemMessage = `
 user는 타로 상담을 하러 온 사람이고, assistant는 타로 상담을 하는 사람이다.
@@ -37,7 +37,7 @@ user와 친근한 반말로 상황에 맞게 대화를 이어서 하시오.
 
 타로 카드를 뽑거나 해설은 아직 하지 않는다.
 
-user가 타로 카드를 뽑을 준비가 되었다고 생각하면, assistant는 "${askTarotCardMessage}"라는 문장을 정확히 말한다.
+user가 타로 카드를 뽑을 준비가 되었다고 생각하면, assistant는 "그럼 ${askTarotCardMessage}"라는 문장을 정확히 말한다.
 
 30토큰 이하로 답변하시오.
 `;

--- a/backend/src/events/events.gateway.ts
+++ b/backend/src/events/events.gateway.ts
@@ -10,7 +10,12 @@ import {
 import { Server, Socket } from 'socket.io';
 import { reamdomWithRange } from 'src/common/utils/ramdomWithRange';
 import { Chat, createTalk, createTarotReading, initChatLog } from './clova';
-import { askTarotCardMessage, maxChatCount, minChatCount } from './constants';
+import {
+  askTarotCardMessage,
+  chatEndMessage,
+  maxChatCount,
+  minChatCount,
+} from './constants';
 
 interface MySocket extends Socket {
   chatLog: Chat[];
@@ -73,7 +78,7 @@ export class EventsGateway
 
       const result = await createTarotReading(client.chatLog, cardName);
       if (result) {
-        const chatEndEvent = () => client.emit('chatEnd');
+        const chatEndEvent = () => client.emit('chatEnd', chatEndMessage);
         readStreamAndSend(client, result.getReader(), chatEndEvent);
       }
     });
@@ -100,7 +105,7 @@ function readStreamAndSend(
         }
 
         if (callback) {
-          callback();
+          setTimeout(callback, 3000);
         }
         return;
       }

--- a/backend/src/events/events.gateway.ts
+++ b/backend/src/events/events.gateway.ts
@@ -57,7 +57,7 @@ export class EventsGateway
       if (client.chatCount === 0) {
         client.chatLog.push({ role: 'user', content: message });
 
-        client.emit('message', askTarotCardMessage);
+        client.emit('message', `그럼 ${askTarotCardMessage}`);
         setTimeout(() => client.emit('tarotCard'), 1000);
 
         return;
@@ -73,7 +73,8 @@ export class EventsGateway
 
       const result = await createTarotReading(client.chatLog, cardName);
       if (result) {
-        readStreamAndSend(client, result.getReader());
+        const chatEndEvent = () => client.emit('chatEnd');
+        readStreamAndSend(client, result.getReader(), chatEndEvent);
       }
     });
   }
@@ -82,6 +83,7 @@ export class EventsGateway
 function readStreamAndSend(
   socket: MySocket,
   reader: ReadableStreamDefaultReader<Uint8Array>,
+  callback?: () => void,
 ) {
   let message = '';
   socket.emit('message', message);
@@ -95,6 +97,10 @@ function readStreamAndSend(
         if (message.includes(askTarotCardMessage)) {
           socket.chatCount = 0;
           setTimeout(() => socket.emit('tarotCard'), 1000);
+        }
+
+        if (callback) {
+          callback();
         }
         return;
       }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -12,6 +12,23 @@
       content="width=device-width, initial-scale=1.0"
     />
     <title>마법의 소라고둥</title>
+    <script>
+      (function (w, d, e, v, o, l, t) {
+        w['ToldWidget'] = o;
+        w[o] =
+          w[o] ||
+          function () {
+            (w[o].q = w[o].q || []).push(arguments);
+          };
+        w[o].l = 1 * new Date();
+        l = document.createElement(e);
+        t = document.getElementsByTagName(e)[0];
+        l.async = 1;
+        l.src = v;
+        t.parentNode.insertBefore(l, t);
+      })(window, document, 'script', 'https://scripts.told.club/sdk/sdk.js', 'told');
+      told('init', '655c51af1d426b320f58f75e');
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/business/hooks/useAiChat/useAiChatMessage.ts
+++ b/frontend/src/business/hooks/useAiChat/useAiChatMessage.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { Message } from '@components/ChatList/ChatList';
+import { Message, MessageButton } from '@components/ChatList/ChatList';
 
 import {
   sendMessage,
@@ -14,12 +14,12 @@ export function useAiChatMessage(tarotCardId: React.MutableRefObject<string | un
   const [messages, setMessages] = useState<Message[]>([]);
   const [messageStreaming, setMessageStreaming] = useState(false);
 
-  const addMessage = (type: 'left' | 'right', message: string) => {
+  const addMessage = (type: 'left' | 'right', message: string, button?: MessageButton) => {
     const tarotId = tarotCardId.current;
     tarotCardId.current = undefined;
 
     const profile = type == 'left' ? '/moon.png' : '/sponge.png';
-    setMessages(messages => [...messages, { type, message, profile, tarotId }]);
+    setMessages(messages => [...messages, { type, message, profile, tarotId, button }]);
   };
 
   const updateMessage = (message: string) => {
@@ -36,7 +36,9 @@ export function useAiChatMessage(tarotCardId: React.MutableRefObject<string | un
     setMessageEventListener(message => addMessage('left', message));
     setMessageUpdateEventListener(message => updateMessage(message));
     setStreamEndEventListener(() => setMessageStreaming(false));
-    setChatEndEventListener(message => addMessage('left', message));
+
+    const button = { content: '피드백하기', onClick: () => alert('피드백하기') };
+    setChatEndEventListener(message => addMessage('left', message, button));
   }, []);
 
   return { messages, messageStreaming, onSubmitMessage };

--- a/frontend/src/business/hooks/useAiChat/useAiChatMessage.ts
+++ b/frontend/src/business/hooks/useAiChat/useAiChatMessage.ts
@@ -37,7 +37,7 @@ export function useAiChatMessage(tarotCardId: React.MutableRefObject<string | un
     setMessageUpdateEventListener(message => updateMessage(message));
     setStreamEndEventListener(() => setMessageStreaming(false));
 
-    const button = { content: '피드백하기', onClick: () => alert('피드백하기') };
+    const button = { content: '피드백하기', onClick: () => alert('👩‍🔧') };
     setChatEndEventListener(message => addMessage('left', message, button));
   }, []);
 

--- a/frontend/src/business/hooks/useAiChat/useAiChatMessage.ts
+++ b/frontend/src/business/hooks/useAiChat/useAiChatMessage.ts
@@ -4,6 +4,7 @@ import { Message } from '@components/ChatList/ChatList';
 
 import {
   sendMessage,
+  setChatEndEventListener,
   setMessageEventListener,
   setMessageUpdateEventListener,
   setStreamEndEventListener,
@@ -35,6 +36,7 @@ export function useAiChatMessage(tarotCardId: React.MutableRefObject<string | un
     setMessageEventListener(message => addMessage('left', message));
     setMessageUpdateEventListener(message => updateMessage(message));
     setStreamEndEventListener(() => setMessageStreaming(false));
+    setChatEndEventListener(message => addMessage('left', message));
   }, []);
 
   return { messages, messageStreaming, onSubmitMessage };

--- a/frontend/src/business/hooks/useAiChat/useAiChatMessage.ts
+++ b/frontend/src/business/hooks/useAiChat/useAiChatMessage.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { Message, MessageButton } from '@components/ChatList/ChatList';
+import { Message, MessageButton } from '@components/ChatList';
 
 import {
   sendMessage,

--- a/frontend/src/business/services/socket.ts
+++ b/frontend/src/business/services/socket.ts
@@ -11,10 +11,6 @@ export function connect() {
   socket = io(URL);
 }
 
-export function getSocket() {
-  return socket;
-}
-
 export function setMessageEventListener(listener: (message: string) => void) {
   socket.on('message', listener);
 }
@@ -26,6 +22,9 @@ export function setStreamEndEventListener(listener: () => void) {
 }
 export function setTarotCardEventListener(listener: () => void) {
   socket.on('tarotCard', listener);
+}
+export function setChatEndEventListener(listener: (message: string) => void) {
+  socket.on('chatEnd', listener);
 }
 
 export function sendMessage(message: string) {

--- a/frontend/src/components/ChatList/ChatList.tsx
+++ b/frontend/src/components/ChatList/ChatList.tsx
@@ -6,6 +6,7 @@ export interface Message {
   message: string;
   profile: string;
   tarotId?: string;
+  feedback?: boolean;
 }
 
 interface ChatListProps {
@@ -26,7 +27,8 @@ function ChatList({ messages }: ChatListProps) {
       ref={messagesRef}
       className={`w-full h-full mb-20 overflow-auto scroll-smooth`}
     >
-      {messages.map(({ type, message, profile, tarotId }, index) => {
+      {messages.map(({ type, message, profile, tarotId, feedback }, index) => {
+        console.log({ type, message, profile, tarotId, feedback });
         return (
           <li
             key={new Date().getTime() + index}
@@ -37,6 +39,7 @@ function ChatList({ messages }: ChatListProps) {
               type={type}
               message={message}
               profile={profile}
+              feedback={feedback}
             />
           </li>
         );

--- a/frontend/src/components/ChatList/ChatList.tsx
+++ b/frontend/src/components/ChatList/ChatList.tsx
@@ -1,12 +1,17 @@
 import MessageBox from '../MessageBox';
 import { useEffect, useRef } from 'react';
 
+export interface MessageButton {
+  content: string;
+  onClick: () => void;
+}
+
 export interface Message {
   type: 'left' | 'right';
   message: string;
   profile: string;
   tarotId?: string;
-  feedback?: boolean;
+  button?: MessageButton;
 }
 
 interface ChatListProps {
@@ -27,8 +32,7 @@ function ChatList({ messages }: ChatListProps) {
       ref={messagesRef}
       className={`w-full h-full mb-20 overflow-auto scroll-smooth`}
     >
-      {messages.map(({ type, message, profile, tarotId, feedback }, index) => {
-        console.log({ type, message, profile, tarotId, feedback });
+      {messages.map(({ type, message, profile, tarotId, button }, index) => {
         return (
           <li
             key={new Date().getTime() + index}
@@ -39,7 +43,7 @@ function ChatList({ messages }: ChatListProps) {
               type={type}
               message={message}
               profile={profile}
-              feedback={feedback}
+              button={button}
             />
           </li>
         );

--- a/frontend/src/components/ChatList/index.ts
+++ b/frontend/src/components/ChatList/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ChatList';
+export type { Message, MessageButton } from './ChatList';

--- a/frontend/src/components/MessageBox/Message.tsx
+++ b/frontend/src/components/MessageBox/Message.tsx
@@ -1,15 +1,13 @@
 import { useMemo } from 'react';
 
+import { MessageButton } from '@components/ChatList';
 import CustomButton from '@components/CustomButton';
 
 interface MessageProps {
   type: 'left' | 'right';
   message: string;
   profile: string;
-  button?: {
-    content: string;
-    onClick: () => void;
-  };
+  button?: MessageButton;
 }
 
 function Message({ type, message, profile, button }: MessageProps) {

--- a/frontend/src/components/MessageBox/Message.tsx
+++ b/frontend/src/components/MessageBox/Message.tsx
@@ -6,10 +6,13 @@ interface MessageProps {
   type: 'left' | 'right';
   message: string;
   profile: string;
-  feedback?: boolean;
+  button?: {
+    content: string;
+    onClick: () => void;
+  };
 }
 
-function Message({ type, message, profile, feedback }: MessageProps) {
+function Message({ type, message, profile, button }: MessageProps) {
   const chatStyle = useMemo(
     () => ({
       box: type == 'left' ? 'chat-start' : 'chat-end',
@@ -31,14 +34,14 @@ function Message({ type, message, profile, feedback }: MessageProps) {
         </div>
         <div className={`chat-bubble max-w-none shadow-chat ${chatStyle.bubble}`}>
           {message}
-          {feedback && (
-            <div className="p-8">
+          {button && (
+            <div className="p-8 pt-12">
               <CustomButton
                 size="m"
                 color="active"
-                handleButtonClicked={() => alert('피드백')}
+                handleButtonClicked={button.onClick}
               >
-                피드백하기
+                {button.content}
               </CustomButton>
             </div>
           )}

--- a/frontend/src/components/MessageBox/Message.tsx
+++ b/frontend/src/components/MessageBox/Message.tsx
@@ -1,12 +1,15 @@
 import { useMemo } from 'react';
 
+import CustomButton from '@components/CustomButton';
+
 interface MessageProps {
   type: 'left' | 'right';
   message: string;
   profile: string;
+  feedback?: boolean;
 }
 
-function Message({ type, message, profile }: MessageProps) {
+function Message({ type, message, profile, feedback }: MessageProps) {
   const chatStyle = useMemo(
     () => ({
       box: type == 'left' ? 'chat-start' : 'chat-end',
@@ -26,7 +29,20 @@ function Message({ type, message, profile }: MessageProps) {
             />
           </div>
         </div>
-        <div className={`chat-bubble max-w-none shadow-chat ${chatStyle.bubble}`}>{message}</div>
+        <div className={`chat-bubble max-w-none shadow-chat ${chatStyle.bubble}`}>
+          {message}
+          {feedback && (
+            <div className="p-8">
+              <CustomButton
+                size="m"
+                color="active"
+                handleButtonClicked={() => alert('피드백')}
+              >
+                피드백하기
+              </CustomButton>
+            </div>
+          )}
+        </div>
       </div>
     </>
   );

--- a/frontend/src/components/MessageBox/Message.tsx
+++ b/frontend/src/components/MessageBox/Message.tsx
@@ -32,20 +32,18 @@ function Message({ type, message, profile, button }: MessageProps) {
             />
           </div>
         </div>
-        <div className={`chat-bubble max-w-none shadow-chat ${chatStyle.bubble}`}>
-          {message}
-          {button && (
-            <div className="p-8 pt-12">
-              <CustomButton
-                size="m"
-                color="active"
-                handleButtonClicked={button.onClick}
-              >
-                {button.content}
-              </CustomButton>
-            </div>
-          )}
-        </div>
+        <div className={`chat-bubble max-w-none shadow-chat ${chatStyle.bubble}`}>{message}</div>
+        {button && (
+          <div className="p-8 pt-12">
+            <CustomButton
+              size="s"
+              color="active"
+              handleButtonClicked={button.onClick}
+            >
+              {button.content}
+            </CustomButton>
+          </div>
+        )}
       </div>
     </>
   );

--- a/frontend/src/components/MessageBox/MessageBox.tsx
+++ b/frontend/src/components/MessageBox/MessageBox.tsx
@@ -8,14 +8,17 @@ interface MessageBoxProps {
   type: 'left' | 'right';
   message: string;
   profile: string;
-  feedback?: boolean;
+  button?: {
+    content: string;
+    onClick: () => void;
+  };
 }
 
 // TODO: tarotId로 서버에서 타로 카드 이미지 정보를 받아와서 src와 alt 채워주기
 // TODO: 조건식 !tarotId -> tarotId로 변경
 // TODO: 프로필 이미지 설정
 
-function MessageBox({ tarotId, type, message, profile, feedback }: MessageBoxProps) {
+function MessageBox({ tarotId, type, message, profile, button }: MessageBoxProps) {
   const recievedResult = tarotId && type == 'left';
 
   return (
@@ -32,7 +35,7 @@ function MessageBox({ tarotId, type, message, profile, feedback }: MessageBoxPro
           type={type}
           message={message}
           profile={profile}
-          feedback={feedback}
+          button={button}
         />
         {recievedResult && (
           <div className="absolute bottom-10 -right-50">

--- a/frontend/src/components/MessageBox/MessageBox.tsx
+++ b/frontend/src/components/MessageBox/MessageBox.tsx
@@ -1,3 +1,4 @@
+import { MessageButton } from '@components/ChatList';
 import CustomButton from '@components/CustomButton';
 import Message from '@components/MessageBox/Message';
 
@@ -8,10 +9,7 @@ interface MessageBoxProps {
   type: 'left' | 'right';
   message: string;
   profile: string;
-  button?: {
-    content: string;
-    onClick: () => void;
-  };
+  button?: MessageButton;
 }
 
 // TODO: tarotId로 서버에서 타로 카드 이미지 정보를 받아와서 src와 alt 채워주기

--- a/frontend/src/components/MessageBox/MessageBox.tsx
+++ b/frontend/src/components/MessageBox/MessageBox.tsx
@@ -1,20 +1,21 @@
-import { Icon } from '@iconify/react/dist/iconify.js';
-
 import CustomButton from '@components/CustomButton';
 import Message from '@components/MessageBox/Message';
+
+import { Icon } from '@iconify/react/dist/iconify.js';
 
 interface MessageBoxProps {
   tarotId?: string;
   type: 'left' | 'right';
   message: string;
   profile: string;
+  feedback?: boolean;
 }
 
 // TODO: tarotId로 서버에서 타로 카드 이미지 정보를 받아와서 src와 alt 채워주기
 // TODO: 조건식 !tarotId -> tarotId로 변경
 // TODO: 프로필 이미지 설정
 
-function MessageBox({ tarotId, type, message, profile }: MessageBoxProps) {
+function MessageBox({ tarotId, type, message, profile, feedback }: MessageBoxProps) {
   const recievedResult = tarotId && type == 'left';
 
   return (
@@ -31,6 +32,7 @@ function MessageBox({ tarotId, type, message, profile }: MessageBoxProps) {
           type={type}
           message={message}
           profile={profile}
+          feedback={feedback}
         />
         {recievedResult && (
           <div className="absolute bottom-10 -right-50">

--- a/frontend/src/pages/AIChatPage/AIChatPage.tsx
+++ b/frontend/src/pages/AIChatPage/AIChatPage.tsx
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 
 import Background from '@components/Background';
 import ChatInput from '@components/ChatInput';
-import ChatList from '@components/ChatList/ChatList';
+import ChatList from '@components/ChatList';
 import CustomButton from '@components/CustomButton';
 import Header from '@components/Header';
 


### PR DESCRIPTION
resolve #169 
resolve #164

### 변경 사항
- MessageBox에 button 추가 가능 하도록 수정
- 타로 결과가 뜨고 어느정도 시간이 흐르고 나서 피드백 요구창이 뜨도록 함.
- told 스크립트를 index.html에 넣어둠. (호스트 네임이 유효하지 않아 error가 뜸 -> 배포 이후 진행 가능)


### 고민과 해결 과정
server에서 타로 해설 3초 이후에 `chatEnd` 이벤트를 발생시킨다.
`chatEnd` 이벤트가 발생하면 화면에 피드백을 요구하는 메세지가 띄워진다.

### (선택) 테스트 결과

![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/fbda9a44-19d8-4c12-97a5-4a079f41aae4)
