### PR TITLE
Fe/feature/#193 공유화면 fetch중일때 fallback처리

### DIFF
--- a/frontend/src/pages/ResultSharePage/ResultSharePage.tsx
+++ b/frontend/src/pages/ResultSharePage/ResultSharePage.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useRef } from 'react';
+import { useRef } from 'react';
 
 import { getResultShareQuery } from '@stores/queries/getResultShareQuery';
 

--- a/frontend/src/pages/ResultSharePage/ResultSharePage.tsx
+++ b/frontend/src/pages/ResultSharePage/ResultSharePage.tsx
@@ -16,22 +16,20 @@ function ResultSharePage({}: ResultSharePageProps) {
   const resultSharePageRef = useRef<HTMLDivElement>(null);
 
   return (
-    <Suspense fallback={<div>loading...</div>}>
-      <div
-        ref={resultSharePageRef}
-        className="w-screen h-full flex flex-all-center gap-80 display-medium16 surface-alt text-strong p-20"
-      >
-        <ResultImage cardUrl={card_url} />
+    <div
+      ref={resultSharePageRef}
+      className="w-screen h-full flex flex-all-center gap-80 display-medium16 surface-alt text-strong p-20"
+    >
+      <ResultImage cardUrl={card_url} />
 
-        <div className="w-664 h-640 flex flex-col rounded-2xl surface-box">
-          <ResultTextBox content={content} />
-          <ShareButtonList
-            cardUrl={card_url}
-            resultSharePageRef={resultSharePageRef}
-          />
-        </div>
+      <div className="w-664 h-640 flex flex-col rounded-2xl surface-box">
+        <ResultTextBox content={content} />
+        <ShareButtonList
+          cardUrl={card_url}
+          resultSharePageRef={resultSharePageRef}
+        />
       </div>
-    </Suspense>
+    </div>
   );
 }
 


### PR DESCRIPTION
### 변경 사항
- 공유 결과 화면에서 suspense 제거

### 고민과 해결 과정
공유 결과 화면에서는 필요 없다고 판단함.
fallback이 있으면 오히려 사용자 경험이 나쁠거라 생각했기 때문.
이미지가 한장밖에 없어서 fallback -> 이동 하면 깜빡거릴 수 있음