### PR TITLE
Fe/feature/#175 custom select 구현

### DIFF
--- a/frontend/src/components/Background/Background.tsx
+++ b/frontend/src/components/Background/Background.tsx
@@ -4,25 +4,26 @@ interface BackgroundProps {
 }
 
 function Background({ children, type = 'default' }: BackgroundProps) {
+  const fadiInIfOpen = type == 'open' ? 'animate-fadeIn' : '';
+  const fadeOutIfClose = type == 'close' ? 'animate-fadeOut' : '';
+  const fadeInIfDynamic = type == 'dynamic' ? 'animate-fadeIn' : '';
+
   return (
-    <div
-      className={`w-screen h-screen flex flex-col justify-center items-center gap-80 ${
-        type == 'open' && 'animate-fadeIn'
-      } ${type == 'close' && 'animate-fadeOut'}`}
-    >
-      <img
-        className="absolute w-full h-full object-cover -z-10"
-        src="/bg.png"
-        alt="밤 하늘의 배경 이미지"
-      />
-      <img
-        className="absolute w-285 h-285 -z-10 animate-shining top-150"
-        src="/moon.png"
-        alt="빛나는 마법의 소라 고둥"
-      />
-      {type != 'default' && (
-        <div className={`absolute w-full h-full bg-black/75 ${type == 'dynamic' && 'animate-fadeIn'}`} />
-      )}
+    <div className={`w-h-screen flex flex-all-center  ${fadiInIfOpen} ${fadeOutIfClose}`}>
+      <div className="w-h-screen absolute -z-10 flex flex-col flex-all-center ">
+        <img
+          className="absolute w-h-screen object-cover -z-10"
+          src="/bg.png"
+          alt="밤 하늘의 배경 이미지"
+        />
+        <img
+          className="absolute w-285 h-285 -z-10 animate-shining top-150"
+          src="/moon.png"
+          alt="빛나는 마법의 소라 고둥"
+        />
+        {type != 'default' && <div className={`absolute w-h-screen bg-black/75 ${fadeInIfDynamic}`} />}
+      </div>
+
       {children}
     </div>
   );

--- a/frontend/src/components/CustomSelect/CustomSelect.tsx
+++ b/frontend/src/components/CustomSelect/CustomSelect.tsx
@@ -1,0 +1,44 @@
+export interface CustomSelectOptions {
+  value: string;
+  label: string;
+  selected?: boolean;
+}
+export interface OnChangeSelectArgs {
+  value: string;
+  label: string;
+}
+
+interface CustomSelectProps {
+  options: CustomSelectOptions[];
+  required?: boolean;
+  autoFocus?: boolean;
+  onChange?: ({ value, label }: OnChangeSelectArgs) => void;
+}
+
+export default function CustomSelect({ options, required, autoFocus, onChange }: CustomSelectProps) {
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const { selectedIndex, options } = e.target;
+    const { value, innerText } = options[selectedIndex];
+
+    onChange?.({ value, label: innerText });
+  };
+
+  return (
+    <select
+      className="select select-bordered w-full"
+      required={required}
+      autoFocus={autoFocus}
+      onChange={handleChange}
+    >
+      {options.map(({ value, label, selected }) => (
+        <option
+          key={value}
+          value={value}
+          selected={selected}
+        >
+          {label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/frontend/src/components/CustomSelect/index.ts
+++ b/frontend/src/components/CustomSelect/index.ts
@@ -1,0 +1,4 @@
+import { CustomSelectOptions, OnChangeSelectArgs } from './CustomSelect';
+
+export { default } from './CustomSelect';
+export type { CustomSelectOptions, OnChangeSelectArgs };

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -123,13 +123,21 @@ export default {
       addComponents(shadowTheme);
     },
     ({ addUtilities }) => {
-      const flexUtils = {
+      const sizeUtil = {
         '.flex-all-center': {
           justifyContent: 'center',
           alignItems: 'center',
         },
+        '.w-h-full': {
+          width: '100%',
+          heght: '100%',
+        },
+        '.w-h-screen': {
+          width: '100vw',
+          height: '100vh',
+        },
       };
-      addUtilities(flexUtils);
+      addUtilities(sizeUtil);
     },
   ],
 };


### PR DESCRIPTION
### 변경 사항
- tailwindcss 유틸 추가
- Background 컴포넌트 수정
- CustomSelect 컴포넌트 구현

### 고민과 해결 과정
#### tailwindcss 유틸 추가
tailwindcss를 사용하면서 w-full h-full 그리고 w-screen w-screen을 같이 사용할 일이 빈번했음
그래서 아래의 유틸을 추가함.
```ts
({ addUtilities }) => {
  const sizeUtil = {
    '.flex-all-center': {
      justifyContent: 'center',
      alignItems: 'center',
    },
    '.w-h-full': {
      width: '100%',
      heght: '100%',
    },
    '.w-h-screen': {
      width: '100vw',
      height: '100vh',
    },
  };
  addUtilities(sizeUtil);
},
```

#### Background 컴포넌트 수정
Background 아래에 children을 넣을 때 style을 absolute로 주지 않으면 뒤로 가려졌음
그래서 배경과 children을 분리함

#### CustomSelect 컴포넌트 구현
아래 형식의 options를 넣어주면 select가 그려지고
```tsx
export interface CustomSelectOptions {
  value: string;
  label: string;
  selected?: boolean;
}
```

onChange 함수를 넣어주면 value와 label을 인자로 넣어줌.
```tsx
interface CustomSelectProps {
  options: CustomSelectOptions[];
  required?: boolean;
  autoFocus?: boolean;
  onChange?: ({ value, label }: OnChangeSelectArgs) => void;
}
```

### (선택) 테스트 결과
<img width="1840" alt="스크린샷 2023-11-22 오전 11 40 47" src="https://github.com/boostcampwm2023/web09-MagicConch/assets/43428643/257def50-adb1-4ea5-afed-a15ac32f703e">
