### PR TITLE
feat: 타로 카드 클릭 시 회전 효과 발생

### DIFF
--- a/frontend/src/components/TarotSpread/TarotCard.tsx
+++ b/frontend/src/components/TarotSpread/TarotCard.tsx
@@ -1,34 +1,31 @@
-import { useState } from 'react';
+import { useMemo } from 'react';
 
 interface TarotCardProps {
   dragging: boolean;
-  index: number;
   backImg: string;
-  onClick: () => void;
+  frontImg: string;
 }
 
-const flipSound = new Audio('/flipCard.mp3');
-
-export default function TarotCard({ dragging, index, backImg, onClick }: TarotCardProps) {
-  const [img, setImg] = useState<string>(backImg);
-
-  const flippedCard = () => {
-    // TODO: react-query api로 이미지를 가져오도록 수정해야 함 & 78개 이미지로 수정
-    flipSound.play();
-    setTimeout(() => setImg(`../../../__tests__/mocks/cards/${(index % 22).toString().padStart(2, '0')}.jpg`), 500);
-  };
-
-  const clickCard = () => {
-    flippedCard();
-    onClick();
-  };
+export default function TarotCard({ dragging, backImg, frontImg }: TarotCardProps) {
+  const tarotCardStyle = useMemo(
+    () => `${dragging && 'hover:animate-tarotHovering'} animate-tarotLeaving w-full h-full -translate-y-1000 absolute`,
+    [dragging],
+  );
 
   return (
-    <img
-      className={`${!dragging && 'hover:animate-tarotHovering'} animate-tarotLeaving w-full h-full -translate-y-1000`}
-      src={img}
-      alt="타로 카드 이미지"
-      onClick={clickCard}
-    />
+    <>
+      <img
+        className={tarotCardStyle}
+        style={{ backfaceVisibility: 'hidden' }}
+        src={backImg}
+        alt="타로 카드 뒷면 이미지"
+      />
+      <img
+        className={tarotCardStyle}
+        style={{ backfaceVisibility: 'hidden', rotate: 'y 180deg' }}
+        src={frontImg}
+        alt="타로 카드 앞면 이미지"
+      />
+    </>
   );
 }

--- a/frontend/src/components/TarotSpread/TarotSpread.tsx
+++ b/frontend/src/components/TarotSpread/TarotSpread.tsx
@@ -104,7 +104,7 @@ export default function TarotSpread({ opened, close, pickCard }: TarotSpreadProp
           <div
             key={idx}
             ref={ref => (tarotCardRefs.current[idx] = ref!)}
-            className="absolute w-full h-full"
+            className="absolute w-h-full"
             onClick={() => flipCard(id, tarotCardRefs.current[idx])}
           >
             <TarotCard


### PR DESCRIPTION
resolve #41 

### 변경 사항
- 카드 선택 시 회전 및 확대
- 코드 가독성 개선

<br>

### 고민과 해결 과정
1️⃣ tailwind의 또 다른 문제점
```
🐞 문제
rotate3d의 기능을 제공하지 않음 
tailwind에서 제공하는 rotate-10 같은 방식은 2d 회전
찾아보니 tailwind는 이러한 3d기능은 보편적이지 않다고 판단해서 공식적으로는 지원하지 않는다고 함
플러그인을 사용하면 되는 것 같지만 적용이 제대로 되지 않음
해당 답변에 대한 댓글을 보니 나만 안되는건 아닌 것 같음 (하다가 포기했다는 반응이 대다수)

✅ 동적으로 style 객체에 설정을 추가함
우선 타켓 요소에 useRef를 걸어두고, 
애니메이션이 실행될 타이밍에 ref.style.transform = "rotateY(..)" 를 설정
transform 이외에도 다른 css를 개별적으로 모두 설정 가능
```
2️⃣ 회전 효과 주기
```
참고: https://solo5star.tistory.com/40

✅ 핵심 속성
- backface-visibility는 rotateY로 인해 180도 뒤집혔을 때 표시할 지 여부를 정하는 옵션
- transform: perspective는 3D 입체 효과를 주기 위한 원근감 옵션
- transform: rotateY는 Y축을 기준으로 회전하는 속성

✅ 카드 구조
<div class="card">
    <div class="front">앞면</div>
    <div class="back">뒷면</div>
</div>

✅ card에 적용
{
  transition: transform 0.3s;
  transform: perspective(800px) rotateY(0deg);
  transform-style: preserve-3d; 
}

transform-style은 3D 공간에서 자식 요소들의 렌더링 방식을 결정
기본값은 flat으로 2D
preserve-3d로 설정할 경우, 해당 영역을 3차원 영역으로 활용하게 됨

✅ front, back에 공통적으로 적용
{
  backface-visibility: hidden; // 뒤집혔을 때 보이지 않도록
}

✅ back만 적용
{
  transform: rotateY(180deg); // 미리 뒤집어 둬야함
}

✅ 선택되었을 때 card에 적용 
{
   transform: perspective(800px) rotateY(180deg); 
   // 뒤집히도록 애니메이션 추가
   // perspective의 경우 원근법 추가
}

```
3️⃣ 카드 선택 알고리즘?
```
🐞 기존 방식의 문제점
선택한 순간에 해당 카드의 이미지 src를 변경해주었음
그러나 이런 방식으로 하게 되면 뒤집는 애니메이션에서 카드 이미지가 제대로 보이지않음
상태값 변경전에 애니메이션이 동작해서 발생하는 문제로 보임

✅ 대안1: 모든 카드의 앞면 이미지를 미리 넣어두자  => ❌
뽑을 카드는 단 하나인데 나머지 카드들의 이미지를 모두 불러오는 것은 비효율적임

✅ 대안2: 하나의 카드에 대한 이미지로 모두 넣어주자 => ⭕️
어차피 뽑는 카드는 단 하나로, 이마저도 랜덤으로 정해줌
그렇다면 컴포넌트를 마운트하는 시점부터 뽑는 카드는 하나로 고정되어있다는 뜻
모든 카드의 뒷면에는 랜덤으로 설정된 카드의 이미지를 불러와서 넣어두기 
```

<br>

### 테스트 결과
https://github.com/boostcampwm2023/web09-MagicConch/assets/69742775/38a2ea3b-d750-448c-a0d0-d569a2436593



