### PR TITLE
Fe/bugfix/#218 mac과 윈도우에서 다르게 보이는 UI 수정

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "^5.8.4",
     "@tanstack/react-query-devtools": "^5.8.4",
     "axios": "^1.6.2",
+    "detect-browser": "^5.3.0",
     "html2canvas": "^1.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   axios:
     specifier: ^1.6.2
     version: 1.6.2
+  detect-browser:
+    specifier: ^5.3.0
+    version: 5.3.0
   html2canvas:
     specifier: ^1.4.1
     version: 1.4.1
@@ -5288,6 +5291,10 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
     dev: true
+
+  /detect-browser@5.3.0:
+    resolution: {integrity: sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==}
+    dev: false
 
   /detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}

--- a/frontend/src/components/Buttons/CustomButton.tsx
+++ b/frontend/src/components/Buttons/CustomButton.tsx
@@ -1,3 +1,5 @@
+import { detect } from 'detect-browser';
+
 export type ButtonColor = 'active' | 'cancel' | 'disabled' | 'dark' | 'transparent';
 export type ButtonSize = 's' | 'm' | 'l';
 
@@ -18,10 +20,13 @@ const colorMap: Record<string, string> = {
   transparent: 'bg-transparent hover:bg-transparent hover:border-transparent',
 };
 
+const browser = detect();
+const __MAC__ = browser?.os?.includes('Mac');
+
 const sizeMap: Record<string, string> = {
-  s: 'h-40 display-bold14 leading-18 p-8 min-h-0',
-  m: 'h-50 display-bold16 leading-20 p-16',
-  l: 'h-60 display-bold16 leading-30 p-16',
+  s: `h-40 display-bold14 ${__MAC__ ? 'leading-18' : ''} p-8 min-h-0`,
+  m: `h-50 display-bold16 ${__MAC__ ? 'leading-20' : ''} p-16`,
+  l: `h-60 display-bold16 ${__MAC__ ? 'leading-30' : ''} p-16`,
 };
 
 function CustomButton({ size, color = 'active', circle = false, disabled = false, children, onClick }: ButtonProps) {

--- a/frontend/src/tailwind.css
+++ b/frontend/src/tailwind.css
@@ -18,6 +18,7 @@ body,
   font-size: 16px;
   width: 100vw;
   height: 100vh;
+  overflow: hidden;
 }
 
 img {
@@ -31,4 +32,8 @@ img {
 *:hover,
 *::-webkit-media-controls-play-button {
   cursor: none;
+}
+
+::-webkit-scrollbar {
+  display: none;
 }


### PR DESCRIPTION
resolve #218 

### 변경 사항
- Mac인지 Window인지에 따라 다른 스타일 지정
- 커스텀 커서가 화면 밖으로 넘어가면 생기는 스크롤 바 제거
- 채팅 길어질 때 생기는 스크롤바도 제거 마우스 스크롤로 대화 스크롤 가능

### 고민과 해결 과정

`detect-browser` 라이브러리 사용해서 os가 뭔지 알아냄

```typescript
import { detect } from 'detect-browser';

const browser = detect();
const __MAC__ = browser?.os?.includes('Mac');

const sizeMap: Record<string, string> = {
  s: `h-40 display-bold14 ${__MAC__ ? 'leading-18' : ''} p-8 min-h-0`,
  m: `h-50 display-bold16 ${__MAC__ ? 'leading-20' : ''} p-16`,
  l: `h-60 display-bold16 ${__MAC__ ? 'leading-30' : ''} p-16`,
};
```

### (선택) 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.