### PR TITLE
Be/feature/#253 도메인 https 적용

### DIFF
--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -64,6 +64,5 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             cd ~/app
-            git pull origin dev
             docker-compose pull
             docker-compose up -d

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -52,7 +52,22 @@ jobs:
           target: "~/app/config/nginx/ssl"
 
       - name: Build Docker Images
-        run: docker-compose build
+        run: |
+          docker-compose build -t ${{ secrets.DOCKER_USERNAME }}/magicconch:${{ github.sha }}
+          cp docker-compose.yml docker-compose.${{ github.sha }}.yml
+
+      - name: Copy docker-compose to Remote Server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          port: ${{ secrets.SSH_PORT }}
+          source: "docker-compose.${{ github.sha }}.yml"
+          target: "~/app"
+
+      - name: Remove local docker-compose copied file
+        run: rm docker-compose.${{ github.sha }}.yml
 
       - name: Push Docker Images to Registry
         uses: docker/login-action@v3
@@ -81,5 +96,6 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             cd ~/app
-            docker-compose pull
-            docker-compose up -d
+            docker rm -f $(docker ps -a -q)
+            docker-compose -f docker-compose.${{ github.sha }}.yml pull
+            docker-compose -f docker-compose.${{ github.sha }}.yml up -d

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -34,6 +34,23 @@ jobs:
           source: ".env"
           target: "~/app"
 
+      - name: Generate SSL files
+        run: |
+          echo ${{ secrets.SSL_OPTIONS }} > config/nginx/ssl/options-ssl-nginx.conf
+          echo ${{ secrets.SSL_FULLCHAIN }} > config/nginx/ssl/fullchain.pem
+          echo ${{ secrets.SSL_PRIVKEY }} > config/nginx/ssl/privkey.pem
+          echo ${{ secrets.SSL_DHPARAMS }} > config/nginx/ssl/ssl-dhparams.pem
+
+      - name: Copy SSL files to Remote Server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          port: ${{ secrets.SSH_PORT }}
+          source: "config/nginx/ssl/*"
+          target: "~/app/config/nginx/ssl"
+
       - name: Build Docker Images
         run: docker-compose build
 

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -53,8 +53,10 @@ jobs:
 
       - name: Build Docker Images
         run: |
-          docker-compose build -t ${{ secrets.DOCKER_USERNAME }}/magicconch:${{ github.sha }}
-          cp docker-compose.yml docker-compose.${{ github.sha }}.yml
+          DOCKER_IMAGE_TAG="${{ github.sha }}"
+          DOCKER_IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/magicconch"
+          docker-compose build -t "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
+          cp docker-compose.yml docker-compose.${DOCKER_IMAGE_TAG}.yml
 
       - name: Copy docker-compose to Remote Server
         uses: appleboy/scp-action@master
@@ -63,7 +65,7 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
-          source: "docker-compose.${{ github.sha }}.yml"
+          source: "docker-compose.${DOCKER_IMAGE_TAG}.yml"
           target: "~/app"
 
       - name: Remove local docker-compose copied file
@@ -97,9 +99,9 @@ jobs:
           script: |
             cd ~/app
             docker rm -f $(docker ps -aq)
-            docker-compose -f docker-compose.${{ github.sha }}.yml pull
-            docker-compose -f docker-compose.${{ github.sha }}.yml up -d
-            while [ -z "$(docker ps -afq name=nest)" ]; do
+            docker-compose -f docker-compose.${DOCKER_IMAGE_TAG}.yml pull
+            docker-compose -f docker-compose.${DOCKER_IMAGE_TAG}.yml up -d
+            while [ -z "$(docker ps -afq name=was)" ]; do
               sleep 5
             done
             sleep 60

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -96,6 +96,11 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             cd ~/app
-            docker rm -f $(docker ps -a -q)
+            docker rm -f $(docker ps -aq)
             docker-compose -f docker-compose.${{ github.sha }}.yml pull
             docker-compose -f docker-compose.${{ github.sha }}.yml up -d
+            while [ -z "$(docker ps -afq name=nest)" ]; do
+              sleep 5
+            done
+            sleep 60
+            rm .env

--- a/Dockerfile.nest
+++ b/Dockerfile.nest
@@ -7,4 +7,6 @@ COPY backend .
 RUN npm install
 RUN npm run build
 
+EXPOSE 3000
+
 CMD ["npm", "run", "start:prod"]

--- a/Dockerfile.nest
+++ b/Dockerfile.nest
@@ -7,6 +7,4 @@ COPY backend .
 RUN npm install
 RUN npm run build
 
-EXPOSE 3000
-
 CMD ["npm", "run", "start:prod"]

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -7,7 +7,4 @@ COPY config/nginx/ssl/fullchain.pem /etc/letsencrypt/live/was.tarotmilktea.com/f
 COPY config/nginx/ssl/privkey.pem /etc/letsencrypt/live/was.tarotmilktea.com/privkey.pem
 COPY config/nginx/ssl/ssl-dhparams.pem /etc/letsencrypt/ssl-dhparams.pem
 
-EXPOSE 80
-EXPOSE 443
-
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -2,6 +2,12 @@ FROM nginx:1.18.0
 
 COPY config/nginx/default.conf /etc/nginx/conf.d/default.conf
 
+COPY config/nginx/ssl/options-ssl-nginx.conf /etc/letsencrypt/options-ssl-nginx.conf
+COPY config/nginx/ssl/fullchain.pem /etc/letsencrypt/live/was.tarotmilktea.com/fullchain.pem
+COPY config/nginx/ssl/privkey.pem /etc/letsencrypt/live/was.tarotmilktea.com/privkey.pem
+COPY config/nginx/ssl/ssl-dhparams.pem /etc/letsencrypt/ssl-dhparams.pem
+
 EXPOSE 80
+EXPOSE 443
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile.was
+++ b/Dockerfile.was
@@ -2,6 +2,7 @@ FROM node:20
 
 WORKDIR /app
 
+# TODO : 추후 시그널링 서버와 구분 필요
 COPY backend .
 
 RUN npm install

--- a/config/nginx/default.conf
+++ b/config/nginx/default.conf
@@ -1,19 +1,39 @@
-upstream nest {
-    server node:3000;
+upstream was {
+    server nest:3000;
 }
 
 server {
-	listen 80;
-	
-	location / {
-	    proxy_pass http://nest;
-	    proxy_http_version 1.1;
-	    proxy_set_header Upgrade $http_upgrade;
-	    proxy_set_header Connection 'upgrade';
-	    proxy_set_header Host $host;
-	    proxy_cache_bypass $http_upgrade;
-	}
-	
-	access_log /var/log/nginx/nest-app-access.log;
-	error_log /var/log/nginx/nest-app-error.log;
+    listen 80;
+    server_name was.tarotmilktea.com;
+
+    location /.well-known/acme-challenge/ {
+        allow all;
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name was.tarotmilktea.com;
+
+    ssl_certificate /etc/letsencrypt/live/was.tarotmilktea.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/was.tarotmilktea.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        proxy_pass http://was;
+        proxy_redirect   default;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    access_log /var/log/nginx/nest-app-access.log;
+    error_log /var/log/nginx/nest-app-error.log;
 }

--- a/config/nginx/default.conf
+++ b/config/nginx/default.conf
@@ -1,7 +1,3 @@
-upstream was {
-    server nest:3000;
-}
-
 server {
     listen 80;
     server_name was.tarotmilktea.com;
@@ -26,7 +22,7 @@ server {
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
     location / {
-        proxy_pass http://was;
+        proxy_pass http://nest:3000;
         proxy_redirect   default;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/config/nginx/default.conf
+++ b/config/nginx/default.conf
@@ -8,7 +8,13 @@ server {
     }
 
     location / {
-        return 301 https://$host$request_uri;
+        proxy_pass http://was:3000;
+        proxy_redirect   default;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $server_name;
     }
 }
 
@@ -22,12 +28,13 @@ server {
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
     location / {
-        proxy_pass http://nest:3000;
+        proxy_pass http://was:3000;
         proxy_redirect   default;
-        proxy_set_header Host $http_host;
+        proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $server_name;
     }
 
     access_log /var/log/nginx/nest-app-access.log;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: "3.3"
 
 services:
-  node:
+  nest:
     build:
       context: .
-      dockerfile: Dockerfile.node
+      dockerfile: Dockerfile.nest
     environment:
       - DB_PORT=${DB_PORT}
       - DB_HOST=${DB_HOST}
@@ -17,14 +17,22 @@ services:
       - X_NCP_APIGW_API_KEY=${X_NCP_APIGW_API_KEY}
     extra_hosts:
       - "host.docker.internal:172.17.0.1"
-    expose:
-      - 3000
 
   nginx:
+    image: nginx:latest
     build:
       context: .
       dockerfile: Dockerfile.nginx
     ports:
-      - "8080:80"
+      - "80:80"
+      - "443:443"
     depends_on:
-      - node
+      - nest
+      - certbot
+
+  certbot:
+    image: certbot/certbot
+    volumes:
+      - /etc/letsencrypt
+      - /var/www/html:/var/www/html
+    command: certonly --webroot --webroot-path=/var/www/html -d was.tarotmilktea.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - X_NCP_APIGW_API_KEY=${X_NCP_APIGW_API_KEY}
     extra_hosts:
       - "host.docker.internal:172.17.0.1"
+    expose:
+      - "3000"
 
   nginx:
     image: nginx:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.3"
 
 services:
-  nest:
-    image: nest
+  was:
+    image: was
     build:
       context: .
-      dockerfile: Dockerfile.nest
+      dockerfile: Dockerfile.was
     environment:
       - DB_PORT=${DB_PORT}
       - DB_HOST=${DB_HOST}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       context: .
       dockerfile: Dockerfile.nginx
     ports:
-      - "80:80"
       - "443:443"
     depends_on:
       - nest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.3"
 
 services:
   nest:
+    image: nest
     build:
       context: .
       dockerfile: Dockerfile.nest
@@ -21,7 +22,7 @@ services:
       - "3000"
 
   nginx:
-    image: nginx:latest
+    image: nginx
     build:
       context: .
       dockerfile: Dockerfile.nginx


### PR DESCRIPTION
### 변경 사항
- SSL 인증서 발급
- HTTPS 적용

[[타로밀크티 기술 블로그] HTTPS 적용하기](https://www.notion.so/HTTPS-a12766a4bbae4aaab356cda4cf8148e5) 

[[타로밀크티 기술 블로그] 521 Web server is down](https://www.notion.so/521-Web-server-is-down-9f0707e307ea4915b655e715fddc9db5)

### 고민과 해결 과정

SSL/TLS 인증서를 발급 받기 위해 Let's Encrypt의 무료 오픈소스를 이용했다.
```bash
certbot --nginx --domains [your_domain]
```
인증서를 발급받으면 각종 키들이 생성되고 다음과 같은 문구가 출력된다.
```bash
Set the `server_name` directive to use the Nginx installer.
```
앞에서 나온 문구를 참고하여 NGINX 설정 파일에 SSL 설정 및 도메인 이름을 적용한다.


#### SSL을 적용하면서 만났던 이슈들
- [expose가 동작하지 않았던 이유 찾기](https://github.com/boostcampwm2023/web09-MagicConch/pull/254#issuecomment-1825928764)
- [ERR 521: Web Server is down 해결하기](https://github.com/boostcampwm2023/web09-MagicConch/pull/254#issuecomment-1825954568)

![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/70785620/f13fc372-3b01-461f-bf11-c58fc9bc75f6)

### (선택) 테스트 결과
