### PR TITLE
Be/bugfix/#262 백엔드 배포 깃허브 액션 오류

### DIFF
--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Generate SSL files
         run: |
+          mkdir -p config/nginx/ssl/
           echo "${{ secrets.SSL_OPTIONS }}" > config/nginx/ssl/options-ssl-nginx.conf
           echo "${{ secrets.SSL_FULLCHAIN }}" > config/nginx/ssl/fullchain.pem
           echo "${{ secrets.SSL_PRIVKEY }}" > config/nginx/ssl/privkey.pem

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -42,6 +42,9 @@ jobs:
           echo "${{ secrets.SSL_PRIVKEY }}" > config/nginx/ssl/privkey.pem
           echo "${{ secrets.SSL_DHPARAMS }}" > config/nginx/ssl/ssl-dhparams.pem
 
+      - name: Create target directory if not exists
+        run: mkdir -p ~/app/config/nginx/ssl
+
       - name: Copy SSL files to Remote Server
         uses: appleboy/scp-action@master
         with:


### PR DESCRIPTION
resolved #262 

### 변경 사항
SSL 파일 생성 시, 부모 디렉토리 먼저 생성하도록 수정

### 고민과 해결 과정
SSL 파일 생성 도중에 다음과 같은 에러가 발생했다.
```
config/nginx/ssl/options-ssl-nginx.conf: No such file or directory
Error: Process completed with exit code 1.
```

파일 생성 전에 `mkdir -p`를 사용하여 부모 디렉토리가 없다면 생성하도록 수정했다.

> `-p` : 모든 부모 디렉토리를 생성해라

### (선택) 테스트 결과
