### PR TITLE
Be/bugfix/#262 백엔드 배포 깃허브 액션 오류

### DIFF
--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -100,10 +100,10 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             cd ~/app
-            docker rm -f $(docker ps -aq)
+            docker rm -f $(docker ps -qa)
             docker-compose -f docker-compose.${{ github.sha }}.yml pull
             docker-compose -f docker-compose.${{ github.sha }}.yml up -d
-            while [ -z "$(docker ps -afq name=app_was)" ]; do
+            while [ -z "$(docker ps -qaf "name=*was*")" ]; do
               sleep 5
             done
             sleep 60

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -57,12 +57,9 @@ jobs:
 
       - name: Build Docker Images
         run: |
-          DOCKER_IMAGE_TAG="${{ github.sha }}"
           DOCKER_IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/magicconch"
-          docker-compose build -t "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
-          cp docker-compose.yml docker-compose.${DOCKER_IMAGE_TAG}.yml
-          cat docker-compose.${DOCKER_IMAGE_TAG}.yml
-          ls
+          docker-compose build -t "${DOCKER_IMAGE_NAME}:${{ github.sha }}"
+          cp docker-compose.yml docker-compose.${{ github.sha }}.yml
 
       - name: Copy docker-compose to Remote Server
         uses: appleboy/scp-action@master
@@ -73,10 +70,9 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           source: "docker-compose.${{ github.sha }}.yml"
           target: "~/app"
-          debug: true
 
       - name: Remove local docker-compose copied file
-        run: rm docker-compose.${DOCKER_IMAGE_TAG}.yml
+        run: rm docker-compose.${{ github.sha }}.yml
 
       - name: Push Docker Images to Registry
         uses: docker/login-action@v3
@@ -106,8 +102,8 @@ jobs:
           script: |
             cd ~/app
             docker rm -f $(docker ps -aq)
-            docker-compose -f docker-compose.${DOCKER_IMAGE_TAG}.yml pull
-            docker-compose -f docker-compose.${DOCKER_IMAGE_TAG}.yml up -d
+            docker-compose -f docker-compose.${{ github.sha }}.yml pull
+            docker-compose -f docker-compose.${{ github.sha }}.yml up -d
             while [ -z "$(docker ps -afq name=was)" ]; do
               sleep 5
             done

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -67,10 +67,7 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
-          source: |
-            docker-compose.${{ github.sha }}.yml
-            Dockerfile.nginx
-            Dockerfile.was
+          source: "docker-compose.${{ github.sha }}.yml,Dockerfile.nginx,Dockerfile.was"
           target: "~/app/"
           overwrite: true
 

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -103,7 +103,7 @@ jobs:
             docker rm -f $(docker ps -aq)
             docker-compose -f docker-compose.${{ github.sha }}.yml pull
             docker-compose -f docker-compose.${{ github.sha }}.yml up -d
-            while [ -z "$(docker ps -afq name=was)" ]; do
+            while [ -z "$(docker ps -afq name=app_was)" ]; do
               sleep 5
             done
             sleep 60

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -32,7 +32,7 @@ jobs:
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
           source: ".env"
-          target: "~/app"
+          target: "~/app/"
 
       - name: Generate SSL files
         run: |
@@ -45,30 +45,34 @@ jobs:
       - name: Create target directory if not exists
         run: mkdir -p ~/app/config/nginx/ssl
 
-      - name: Copy SSL files to Remote Server
+      - name: Copy nginx configuration and SSL files to Remote Server
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME }}
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
-          source: "config/nginx/ssl/*"
-          target: "~/app/config/nginx/ssl"
+          source: "config/nginx/*"
+          target: "~/app/config/nginx/"
 
       - name: Build Docker Images
         run: |
           docker-compose build -t "${{ secrets.DOCKER_USERNAME }}/magicconch:${{ github.sha }}"
           cp docker-compose.yml docker-compose.${{ github.sha }}.yml
 
-      - name: Copy docker-compose to Remote Server
+      - name: Copy Dockerfiles to Remote Server
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME }}
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
-          source: "docker-compose.${{ github.sha }}.yml"
-          target: "~/app"
+          source: |
+            docker-compose.${{ github.sha }}.yml
+            Dockerfile.nginx
+            Dockerfile.was
+          target: "~/app/"
+          overwrite: true
 
       - name: Remove local docker-compose copied file
         run: rm docker-compose.${{ github.sha }}.yml

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -71,8 +71,9 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
-          source: "docker-compose.${DOCKER_IMAGE_TAG}.yml"
+          source: "docker-compose.${{ github.sha }}.yml"
           target: "~/app"
+          debug: true
 
       - name: Remove local docker-compose copied file
         run: rm docker-compose.${DOCKER_IMAGE_TAG}.yml

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -2,7 +2,7 @@ name: Dockerized CD
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["dev", "BE/bugfix/#262-백엔드-배포-깃허브-액션-오류"]
 
 jobs:
   build:
@@ -61,6 +61,8 @@ jobs:
           DOCKER_IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/magicconch"
           docker-compose build -t "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
           cp docker-compose.yml docker-compose.${DOCKER_IMAGE_TAG}.yml
+          cat docker-compose.${DOCKER_IMAGE_TAG}.yml
+          ls
 
       - name: Copy docker-compose to Remote Server
         uses: appleboy/scp-action@master
@@ -73,7 +75,7 @@ jobs:
           target: "~/app"
 
       - name: Remove local docker-compose copied file
-        run: rm docker-compose.${{ github.sha }}.yml
+        run: rm docker-compose.${DOCKER_IMAGE_TAG}.yml
 
       - name: Push Docker Images to Registry
         uses: docker/login-action@v3

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -57,8 +57,7 @@ jobs:
 
       - name: Build Docker Images
         run: |
-          DOCKER_IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/magicconch"
-          docker-compose build -t "${DOCKER_IMAGE_NAME}:${{ github.sha }}"
+          docker-compose build -t "${{ secrets.DOCKER_USERNAME }}/magicconch:${{ github.sha }}"
           cp docker-compose.yml docker-compose.${{ github.sha }}.yml
 
       - name: Copy docker-compose to Remote Server

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -2,7 +2,7 @@ name: Dockerized CD
 
 on:
   push:
-    branches: ["dev", "BE/bugfix/#262-백엔드-배포-깃허브-액션-오류"]
+    branches: ["dev"]
 
 jobs:
   build:

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -103,7 +103,7 @@ jobs:
             docker rm -f $(docker ps -qa)
             docker-compose -f docker-compose.${{ github.sha }}.yml pull
             docker-compose -f docker-compose.${{ github.sha }}.yml up -d
-            while [ -z "$(docker ps -qaf "name=*was*")" ]; do
+            while [ -z "$(docker ps -qaf "name=was")" ]; do
               sleep 5
             done
             sleep 60

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.3"
 
 services:
   was:
-    image: was
     build:
       context: .
       dockerfile: Dockerfile.was
@@ -22,7 +21,6 @@ services:
       - "3000"
 
   nginx:
-    image: nginx
     build:
       context: .
       dockerfile: Dockerfile.nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     ports:
       - "443:443"
     depends_on:
-      - nest
+      - was
       - certbot
 
   certbot:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       context: .
       dockerfile: Dockerfile.nginx
     ports:
+      - "80:80"
       - "443:443"
     depends_on:
       - was


### PR DESCRIPTION
resolved #262 

### 변경 사항
- `nest`에서 `was`로 바꾼 것 적용
- 환경변수 문제 해결
- nginx 컨테이너의 80번 포트와 호스트 서버의 80번 포트 매핑

### 고민과 해결 과정
`DOCKER_IMAGE_TAG`라는 환경변수를 선언하여 사용했는데 다른 코드 블록에서 `DOCKER_IMAGE_TAG`에 접근하지 못하는 문제를 발견했다. `DOCKER_IMAGE_TAG` 대신 `${{ github.sha }}`를 사용하여 오류를 해결했다.

```diff
      - name: Build Docker Images
        run: |
-          DOCKER_IMAGE_TAG="${{ github.sha }}"
          ...

      - name: Copy docker-compose to Remote Server
        uses: appleboy/scp-action@master
        with:
          host: ${{ secrets.SSH_HOST }}
          username: ${{ secrets.SSH_USERNAME }}
          password: ${{ secrets.SSH_PASSWORD }}
          port: ${{ secrets.SSH_PORT }}
-          source: "docker-compose.${DOCKER_IMAGE_TAG}.yml"
+          source: "docker-compose.${{ github.sha }}.yml"
          target: "~/app"
```

### (선택) 테스트 결과