### PR TITLE
Fe/feature/#14,#171 팝업창 UI 구현

### DIFF
--- a/frontend/src/components/Popup/PasswordPopup.tsx
+++ b/frontend/src/components/Popup/PasswordPopup.tsx
@@ -1,0 +1,47 @@
+import { useRef } from 'react';
+
+import Popup from './Popup';
+
+interface PasswordPopupProps {
+  close: () => void;
+  onCancel?: () => void;
+  defaultValue?: string;
+  onSubmit: (password: string) => void;
+}
+
+export default function PasswordPopup({ close, onCancel, defaultValue, onSubmit }: PasswordPopupProps) {
+  const passwordInput = useRef<HTMLInputElement>(null);
+
+  const passwordSubmit = () => {
+    const password = passwordInput.current?.value;
+    if (password) {
+      onSubmit(password || '');
+    }
+  };
+
+  const formSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    passwordSubmit();
+  };
+
+  return (
+    <Popup
+      close={close}
+      onCancel={onCancel}
+      onConfirm={passwordSubmit}
+    >
+      <form
+        className="flex-with-center flex-col gap-16"
+        onSubmit={formSubmit}
+      >
+        <div>비밀번호를 {defaultValue ? '설정' : '입력'}하세요</div>
+        <input
+          ref={passwordInput}
+          type="text"
+          className="input input-bordered input-sm"
+          defaultValue={defaultValue}
+        />
+      </form>
+    </Popup>
+  );
+}

--- a/frontend/src/components/Popup/Popup.tsx
+++ b/frontend/src/components/Popup/Popup.tsx
@@ -18,9 +18,7 @@ export default function Popup({ close, onCancel, onConfirm, children }: PopupPro
             color="dark"
             onClick={() => {
               close();
-              if (onCancel) {
-                onCancel();
-              }
+              onCancel?.();
             }}
           >
             취소하기

--- a/frontend/src/components/Popup/Popup.tsx
+++ b/frontend/src/components/Popup/Popup.tsx
@@ -1,0 +1,35 @@
+import { CustomButton } from '@components/Buttons';
+
+interface PopupProps {
+  opened: boolean;
+  close: () => void;
+  onCancel?: () => void;
+  onConfirm?: () => void;
+  children: React.ReactNode;
+}
+
+export default function Popup({ onCancel, onConfirm, children }: PopupProps) {
+  return (
+    <div className="w-[100vw] h-[100vh] flex-with-center">
+      <div className="surface-content rounded p-16 gap-16">
+        <div className="flex-with-center flex-row gap-16 p-16 display-bold16">{children}</div>
+        <div className="flex justify-around p-12">
+          <CustomButton
+            size="m"
+            color="dark"
+            onClick={onCancel}
+          >
+            취소하기
+          </CustomButton>
+          <CustomButton
+            size="m"
+            color="active"
+            onClick={onConfirm}
+          >
+            확인하기
+          </CustomButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Popup/Popup.tsx
+++ b/frontend/src/components/Popup/Popup.tsx
@@ -1,14 +1,13 @@
 import { CustomButton } from '@components/Buttons';
 
 interface PopupProps {
-  opened: boolean;
   close: () => void;
   onCancel?: () => void;
   onConfirm?: () => void;
   children: React.ReactNode;
 }
 
-export default function Popup({ onCancel, onConfirm, children }: PopupProps) {
+export default function Popup({ close, onCancel, onConfirm, children }: PopupProps) {
   return (
     <div className="w-[100vw] h-[100vh] flex-with-center">
       <div className="surface-content rounded p-16 gap-16">
@@ -17,7 +16,12 @@ export default function Popup({ onCancel, onConfirm, children }: PopupProps) {
           <CustomButton
             size="m"
             color="dark"
-            onClick={onCancel}
+            onClick={() => {
+              close();
+              if (onCancel) {
+                onCancel();
+              }
+            }}
           >
             취소하기
           </CustomButton>

--- a/frontend/src/components/Popup/Popup.tsx
+++ b/frontend/src/components/Popup/Popup.tsx
@@ -11,7 +11,7 @@ export default function Popup({ close, onCancel, onConfirm, children }: PopupPro
   return (
     <div className="w-[100vw] h-[100vh] flex-with-center">
       <div className="surface-content rounded p-16 gap-16">
-        <div className="flex-with-center flex-row gap-16 p-16 display-bold16">{children}</div>
+        <div className="flex-with-center p-16 display-bold16">{children}</div>
         <div className="flex justify-around p-12">
           <CustomButton
             size="m"

--- a/frontend/src/components/Popup/index.tsx
+++ b/frontend/src/components/Popup/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Popup';

--- a/frontend/src/components/Popup/index.tsx
+++ b/frontend/src/components/Popup/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './Popup';
+export { default as PasswordPopup } from './PasswordPopup';


### PR DESCRIPTION
resolve #171
resolve #14

### 변경 사항
- Popup component 작성함.
- PasswordPopup component 작성함.

### 고민과 해결 과정

**1️⃣ Popup component**
```typescript
interface PopupProps {
  close: () => void;
  onCancel?: () => void;
  onConfirm?: () => void;
  children: React.ReactNode;
}
```

- onCancel, onConfirm: `취소하기`, `확인하기` 버튼 클릭 시  실행할 이벤트를 설정 할 수 있다.

사용 예시
```typescript
const showPopup = () => {
      open(({ close }) => <Popup close={close}>상담자에게 타로카드가 펼쳐집니다.</Popup>);
};
```

**2️⃣ PasswordPopup component**
```typescript
interface PasswordPopupProps {
  close: () => void;
  onCancel?: () => void;
  defaultValue?: string;
  onSubmit: (password: string) => void;
}
```

- defaultValue: 기본 비밀번호 값  
참고) defaultValue가 설정되어있는지 여부에 따라 텍스트가 다름.  
`<div>비밀번호를 {defaultValue ? '설정' : '입력'}하세요</div>`

사용 예시
```typescript
const showPopup = () => {
  open(({ close }) => (
    <PasswordPopup
      close={close}
      defaultValue="1234"
      onSubmit={password => alert(password)}
    />
  ));
}
```

### (선택) 테스트 결과

![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/92383dcd-d7c8-4670-9c6b-24781a24818a)

![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/b451aa3c-695f-448b-b745-248324e88054)