### PR TITLE
Fe/bugfix/#250 aichatpage 새로고침을 하거나 뒤로갔다가 다시 왔을 때 제대로 동작 안하는 버그

### DIFF
--- a/frontend/src/business/hooks/useSocket.ts
+++ b/frontend/src/business/hooks/useSocket.ts
@@ -11,14 +11,25 @@ interface SocketTypesMap {
   };
 }
 
+type ConnectSocketOptions = {
+  reconnect: boolean;
+};
+
 type SocketType = keyof SocketTypesMap;
 
 const sockets = {} as Record<SocketType, Socket>;
 
 export function useSocket<T extends SocketType>(socketType: T) {
-  function connectSocket(url: string) {
+  const ConnectSocketDefaultOptions = {
+    reconnect: false,
+  };
+
+  function connectSocket(url: string, { reconnect }: ConnectSocketOptions = ConnectSocketDefaultOptions) {
     if (sockets[socketType]) {
-      throw new Error('소켓이 이미 존재합니다.');
+      if (!reconnect) {
+        throw new Error('소켓이 이미 존재합니다.');
+      }
+      sockets[socketType].disconnect();
     }
     sockets[socketType] = io(url);
   }

--- a/frontend/src/business/hooks/useSocket.ts
+++ b/frontend/src/business/hooks/useSocket.ts
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { Socket, io } from 'socket.io-client';
 
 interface SocketTypesMap {
@@ -20,6 +21,8 @@ type SocketType = keyof SocketTypesMap;
 const sockets = {} as Record<SocketType, Socket>;
 
 export function useSocket<T extends SocketType>(socketType: T) {
+  const navigate = useNavigate();
+
   const ConnectSocketDefaultOptions = {
     reconnect: false,
   };
@@ -43,10 +46,18 @@ export function useSocket<T extends SocketType>(socketType: T) {
   }
 
   function socketOn<U>(eventName: SocketTypesMap[T]['OnEventName'], eventListener: (args: U) => void) {
+    if (!sockets[socketType]) {
+      navigate('/');
+      return;
+    }
     sockets[socketType].on(eventName, eventListener as any);
   }
 
   function socketEmit(eventName: SocketTypesMap[T]['EmitEventName'], ...eventArgs: unknown[]) {
+    if (!sockets[socketType]) {
+      navigate('/');
+      return;
+    }
     sockets[socketType].emit(eventName, ...eventArgs);
   }
 

--- a/frontend/src/pages/HomePage/HomePage.tsx
+++ b/frontend/src/pages/HomePage/HomePage.tsx
@@ -10,7 +10,7 @@ function HomePage() {
   const { connectSocket } = useSocket('AIChat');
 
   const moveAiChat = () => {
-    connectSocket(import.meta.env.VITE_WAS_URL);
+    connectSocket(import.meta.env.VITE_WAS_URL, { reconnect: true });
 
     navigate('/chat/ai');
   };


### PR DESCRIPTION
resolve #250 

### 변경 사항
- home에서 connectSocket reconnect 옵션 추가해서 기존 소켓이 이미 존재할 경우, 기존 연결을 끊고 새로 연결하게 함.
- socket 에러 시 (aichatpage에서 새로고침 시에 연결이 끊겨 socket을 찾을 수 없음) home으로 이동하도록 함

### 고민과 해결 과정

### (선택) 테스트 결과

뒤로 갔다가 다시 aichat으로 이동하는 경우

![녹화_2023_11_27_13_44_29_43](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/0333faa1-6c57-4f01-9fb1-c308d8f48d28)

aichat에서 새로고침하는 경우

![녹화_2023_11_27_13_42_36_220](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/63d2881c-34e7-477b-9ec3-a25300ed7c25)
