### PR TITLE
Fe/feature/#176 프로필 설정 팝업 UI 구성 & IconToggleButton 추가

### DIFF
--- a/frontend/src/components/Buttons/IconToggleButton.tsx
+++ b/frontend/src/components/Buttons/IconToggleButton.tsx
@@ -1,0 +1,32 @@
+import { ButtonSize } from './CustomButton';
+import IconButton from './IconButton';
+
+interface IconToggleButtonProps {
+  activeIcon: string;
+  disabledIcon: string;
+  iconSize?: number;
+  buttonSize?: ButtonSize;
+  onClick?: () => void;
+  active: boolean;
+}
+
+export default function IconToggleButton({
+  activeIcon,
+  disabledIcon,
+  iconSize,
+  buttonSize,
+  onClick,
+  active,
+}: IconToggleButtonProps) {
+  return (
+    <IconButton
+      icon={active ? activeIcon : disabledIcon}
+      iconSize={iconSize}
+      iconColor={active ? 'textWhite' : 'textDefault'}
+      buttonSize={buttonSize}
+      buttonColor={active ? 'active' : 'cancel'}
+      onClick={onClick}
+      circle
+    />
+  );
+}

--- a/frontend/src/components/Buttons/index.ts
+++ b/frontend/src/components/Buttons/index.ts
@@ -1,5 +1,6 @@
 import CustomButton from './CustomButton';
 import IconButton from './IconButton';
+import IconToggleButton from './IconToggleButton';
 import LogoButton from './LogoButton';
 
-export { CustomButton, IconButton, LogoButton };
+export { CustomButton, IconButton, LogoButton, IconToggleButton };

--- a/frontend/src/components/ProfileSetting/DeviceSelect.tsx
+++ b/frontend/src/components/ProfileSetting/DeviceSelect.tsx
@@ -1,0 +1,19 @@
+import CustomSelect, { CustomSelectOptions } from '@components/CustomSelect';
+
+interface DeviceSelectProps {
+  name: string;
+  deviceList: CustomSelectOptions[];
+  onChange: (deviceId: string) => void;
+}
+
+export default function DeviceSelect({ name, deviceList, onChange }: DeviceSelectProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <span className="text-strong display-bold14">사용할 {name} 장치를 선택하세요.</span>
+      <CustomSelect
+        options={deviceList}
+        onChange={({ value }) => onChange(value)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/ProfileSetting/DeviceToggleButtons.tsx
+++ b/frontend/src/components/ProfileSetting/DeviceToggleButtons.tsx
@@ -1,0 +1,36 @@
+import { IconToggleButton } from '@components/Buttons';
+
+interface DeviceToggleButtonsProps {
+  cameraActive: boolean;
+  micActive: boolean;
+  cameraToggle: () => void;
+  micToggle: () => void;
+}
+
+export default function DeviceToggleButtons({
+  cameraActive,
+  micActive,
+  cameraToggle,
+  micToggle,
+}: DeviceToggleButtonsProps) {
+  return (
+    <div className="flex-with-center gap-36">
+      <IconToggleButton
+        activeIcon="pepicons-pop:camera"
+        disabledIcon="pepicons-pop:camera-off"
+        iconSize={28}
+        buttonSize="l"
+        active={cameraActive}
+        onClick={cameraToggle}
+      />
+      <IconToggleButton
+        activeIcon="mingcute:mic-line"
+        disabledIcon="mingcute:mic-off-line"
+        iconSize={28}
+        buttonSize="l"
+        active={micActive}
+        onClick={micToggle}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/ProfileSetting/ProfileSetting.tsx
+++ b/frontend/src/components/ProfileSetting/ProfileSetting.tsx
@@ -1,10 +1,13 @@
 import { useState } from 'react';
 
-import { IconToggleButton } from '@components/Buttons';
+import { CustomButton, IconButton, IconToggleButton } from '@components/Buttons';
+import CustomSelect from '@components/CustomSelect';
 
-interface ProfileSettingProps {}
+interface ProfileSettingProps {
+  close: () => void;
+}
 
-export default function ProfileSetting({}: ProfileSettingProps) {
+export default function ProfileSetting({ close }: ProfileSettingProps) {
   const [cameraActive, setCameraActive] = useState(true);
   const [micActive, setMicActive] = useState(true);
 
@@ -15,16 +18,28 @@ export default function ProfileSetting({}: ProfileSettingProps) {
     setMicActive(micActive => !micActive);
   };
 
+  const camList = [
+    { label: '카메라1', value: 'camera1', selected: true },
+    { label: '카메라2', value: 'camera2' },
+    { label: '카메라3', value: 'camera3' },
+  ];
+
+  const micList = [
+    { label: '마이크1', value: 'mic1', selected: true },
+    { label: '마이크2', value: 'mic2' },
+    { label: '마이크3', value: 'mic3' },
+  ];
+
   return (
     <div className="w-[100vw] h-[100vh] flex-with-center">
-      <div className="flex-with-center gap-48 rounded-lg p-64 surface-box">
-        <div className="flex-with-center flex-col gap-32">
+      <div className="flex gap-48 rounded-lg p-64 surface-box">
+        <div className="flex flex-col gap-24">
           {/* TODO: Cam component기 완성되면 바꿔야 함. */}
           <img
-            className="w-240 h-240"
+            className="w-320 h-320"
             src="/ddung.png"
           />
-          <div className="flex-with-center gap-28">
+          <div className="flex-with-center gap-36">
             <IconToggleButton
               activeIcon="pepicons-pop:camera"
               disabledIcon="pepicons-pop:camera-off"
@@ -42,6 +57,44 @@ export default function ProfileSetting({}: ProfileSettingProps) {
               onClick={micToggle}
             />
           </div>
+        </div>
+        <div className="flex flex-col gap-24">
+          <div className="flex-with-center gap-12">
+            <div className="flex flex-col gap-4">
+              <span className="text-strong display-bold14">프로필 이미지를 설정하세요.</span>
+              <span className="text-strong display-medium12">카메라가 off 되었을 때 표시됩니다.</span>
+            </div>
+            <IconButton
+              icon="ph:camera-bold"
+              iconColor="textWhite"
+              iconSize={24}
+              buttonSize="m"
+              buttonColor="dark"
+              circle
+            />
+          </div>
+          <div className="flex flex-col gap-4">
+            <span className="text-strong display-bold14">상대방에게 표시될 이름을 입력하세요.</span>
+            <input
+              className="input input-bordered input-sm"
+              type="text"
+              placeholder="닉네임을 입력하세요."
+            />
+          </div>
+          <div className="flex flex-col gap-4">
+            <span className="text-strong display-bold14">사용할 카메라 장치를 선택하세요.</span>
+            <CustomSelect options={camList} />
+          </div>
+          <div className="flex flex-col gap-4">
+            <span className="text-strong display-bold14">사용할 오디오 장치를 선택하세요.</span>
+            <CustomSelect options={micList} />
+          </div>
+          <CustomButton
+            onClick={close}
+            color="dark"
+          >
+            확인
+          </CustomButton>
         </div>
       </div>
     </div>

--- a/frontend/src/components/ProfileSetting/ProfileSetting.tsx
+++ b/frontend/src/components/ProfileSetting/ProfileSetting.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { CustomButton, IconButton, IconToggleButton } from '@components/Buttons';
 
 import DeviceSelect from './DeviceSelect';
+import DeviceToggleButtons from './DeviceToggleButtons';
 
 interface ProfileSettingProps {
   close: () => void;
@@ -40,24 +41,12 @@ export default function ProfileSetting({ close }: ProfileSettingProps) {
             className="w-320 h-320"
             src="/ddung.png"
           />
-          <div className="flex-with-center gap-36">
-            <IconToggleButton
-              activeIcon="pepicons-pop:camera"
-              disabledIcon="pepicons-pop:camera-off"
-              iconSize={28}
-              buttonSize="l"
-              active={cameraActive}
-              onClick={cameraToggle}
-            />
-            <IconToggleButton
-              activeIcon="mingcute:mic-line"
-              disabledIcon="mingcute:mic-off-line"
-              iconSize={28}
-              buttonSize="l"
-              active={micActive}
-              onClick={micToggle}
-            />
-          </div>
+          <DeviceToggleButtons
+            cameraActive={cameraActive}
+            micActive={micActive}
+            cameraToggle={cameraToggle}
+            micToggle={micToggle}
+          />
         </div>
         <div className="flex flex-col gap-24">
           <div className="flex-with-center gap-12">

--- a/frontend/src/components/ProfileSetting/ProfileSetting.tsx
+++ b/frontend/src/components/ProfileSetting/ProfileSetting.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { CustomButton, IconButton, IconToggleButton } from '@components/Buttons';
+import { CustomButton, IconButton } from '@components/Buttons';
 
 import DeviceSelect from './DeviceSelect';
 import DeviceToggleButtons from './DeviceToggleButtons';

--- a/frontend/src/components/ProfileSetting/ProfileSetting.tsx
+++ b/frontend/src/components/ProfileSetting/ProfileSetting.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 
 import { CustomButton, IconButton, IconToggleButton } from '@components/Buttons';
-import CustomSelect from '@components/CustomSelect';
+
+import DeviceSelect from './DeviceSelect';
 
 interface ProfileSettingProps {
   close: () => void;
@@ -81,14 +82,16 @@ export default function ProfileSetting({ close }: ProfileSettingProps) {
               placeholder="닉네임을 입력하세요."
             />
           </div>
-          <div className="flex flex-col gap-4">
-            <span className="text-strong display-bold14">사용할 카메라 장치를 선택하세요.</span>
-            <CustomSelect options={camList} />
-          </div>
-          <div className="flex flex-col gap-4">
-            <span className="text-strong display-bold14">사용할 오디오 장치를 선택하세요.</span>
-            <CustomSelect options={micList} />
-          </div>
+          <DeviceSelect
+            name="카메라"
+            deviceList={camList}
+            onChange={console.log}
+          />
+          <DeviceSelect
+            name="마이크"
+            deviceList={micList}
+            onChange={console.log}
+          />
           <CustomButton
             onClick={close}
             color="dark"

--- a/frontend/src/components/ProfileSetting/ProfileSetting.tsx
+++ b/frontend/src/components/ProfileSetting/ProfileSetting.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+
+import { IconToggleButton } from '@components/Buttons';
+
+interface ProfileSettingProps {}
+
+export default function ProfileSetting({}: ProfileSettingProps) {
+  const [cameraActive, setCameraActive] = useState(true);
+  const [micActive, setMicActive] = useState(true);
+
+  const cameraToggle = () => {
+    setCameraActive(cameraActive => !cameraActive);
+  };
+  const micToggle = () => {
+    setMicActive(micActive => !micActive);
+  };
+
+  return (
+    <div className="w-[100vw] h-[100vh] flex-with-center">
+      <div className="flex-with-center gap-48 rounded-lg p-64 surface-box">
+        <div className="flex-with-center flex-col gap-32">
+          {/* TODO: Cam component기 완성되면 바꿔야 함. */}
+          <img
+            className="w-240 h-240"
+            src="/ddung.png"
+          />
+          <div className="flex-with-center gap-28">
+            <IconToggleButton
+              activeIcon="pepicons-pop:camera"
+              disabledIcon="pepicons-pop:camera-off"
+              iconSize={28}
+              buttonSize="l"
+              active={cameraActive}
+              onClick={cameraToggle}
+            />
+            <IconToggleButton
+              activeIcon="mingcute:mic-line"
+              disabledIcon="mingcute:mic-off-line"
+              iconSize={28}
+              buttonSize="l"
+              active={micActive}
+              onClick={micToggle}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ProfileSetting/index.tsx
+++ b/frontend/src/components/ProfileSetting/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ProfileSetting';

--- a/frontend/src/components/ProfileSettingOverlay/ProfileSettingOverlay.tsx
+++ b/frontend/src/components/ProfileSettingOverlay/ProfileSettingOverlay.tsx
@@ -1,7 +1,0 @@
-interface ProfileSettingOverlayProps {}
-
-function ProfileSettingOverlay({}: ProfileSettingOverlayProps){
-  return <></>;
-};
-
-export default ProfileSettingOverlay;

--- a/frontend/src/components/ProfileSettingOverlay/index.ts
+++ b/frontend/src/components/ProfileSettingOverlay/index.ts
@@ -1,1 +1,0 @@
-export { default } from './ProfileSettingOverlay';


### PR DESCRIPTION
resolve #176

### 변경 사항
- ProfileSetting 컴포넌트 작성
- IconToggleButton 컴포넌트 추가

### 고민과 해결 과정

**기존 IconButton을 활용해서 IconToggleButton 작성함**
```typescript
import { ButtonSize } from './CustomButton';
import IconButton from './IconButton';

interface IconToggleButtonProps {
  activeIcon: string;
  disabledIcon: string;
  iconSize?: number;
  buttonSize?: ButtonSize;
  onClick?: () => void;
  active: boolean;
}

export default function IconToggleButton({
  activeIcon,
  disabledIcon,
  iconSize,
  buttonSize,
  onClick,
  active,
}: IconToggleButtonProps) {
  return (
    <IconButton
      icon={active ? activeIcon : disabledIcon}
      iconSize={iconSize}
      iconColor={active ? 'textWhite' : 'textDefault'}
      buttonSize={buttonSize}
      buttonColor={active ? 'active' : 'cancel'}
      onClick={onClick}
      circle
    />
  );
}
```

### (선택) 테스트 결과
![녹화_2023_11_27_15_27_39_114](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/8a04eff2-1eef-45c4-8023-10c9bc1d4506)
