### PR TITLE
fix: audio 재생 input 크기와 외부 버튼 크기 맞추기

### DIFF
--- a/frontend/src/components/BackgroundMusic/BackgroundMusic.tsx
+++ b/frontend/src/components/BackgroundMusic/BackgroundMusic.tsx
@@ -19,8 +19,8 @@ function BackgroundMusic() {
   };
 
   return (
-    <div className="w-70 h-70 overflow-hidden fixed bottom-30 left-35">
-      <div className="absolute top-5 left-5">
+    <div className="w-60 h-60 overflow-hidden fixed bottom-30 left-35">
+      <div className="absolute top-0 left-0">
         <CustomButton
           color={playing ? 'active' : 'disabled'}
           size="l"
@@ -32,7 +32,7 @@ function BackgroundMusic() {
         </CustomButton>
       </div>
       <audio
-        className="opacity-0 absolute -top-18 left-7 h-80"
+        className="opacity-0 absolute top-0 -left-10 h-60"
         loop
         controls
         src={backgroundMusicURL}

--- a/frontend/src/tailwind.css
+++ b/frontend/src/tailwind.css
@@ -37,3 +37,14 @@ img {
 ::-webkit-scrollbar {
   display: none;
 }
+
+audio::-webkit-media-controls-enclosure {
+  max-height: none;
+}
+
+audio::-webkit-media-controls-play-button {
+  height: 60px;
+  width: 60px;
+  min-width: 0;
+  padding: 30px;
+}


### PR DESCRIPTION
resolve #255 

### 변경 사항
- 재생 버튼 위에서 커서가 활성화 되었는데도 음악 재생 클릭이 되지 않는 문제 해결
  - 외부 버튼 보다 숨겨진 audio의 재생 버튼이 작아서 생기는 문제
  - 둘의 크기를 맞춰서 해결함 


