### PR TITLE
Fe/feature/#261 데이터 채널을 사용해 채팅을 주고 받을 수 있어야 함

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ import ResultSharePage from './pages/ResultSharePage';
 import BackgroundMusic from './components/BackgroundMusic';
 import Cursor from '@components/Cursor';
 
+import { MediaInfoProvider } from '@business/providers/MediaInfoProvider';
+
 function App() {
   return (
     <>
@@ -23,7 +25,11 @@ function App() {
         />
         <Route
           path="/chat/human/:roomName"
-          element={<HumanChatPage />}
+          element={
+            <MediaInfoProvider>
+              <HumanChatPage />
+            </MediaInfoProvider>
+          }
         >
           <Route
             path="/chat/human/:roomName"

--- a/frontend/src/business/hooks/useDataChannel.ts
+++ b/frontend/src/business/hooks/useDataChannel.ts
@@ -20,7 +20,10 @@ export function useDataChannel({ peerConnectionRef }: useDataChannelProps) {
       negotiated: true,
       id: 0,
     });
-    chatChannel.current = peerConnectionRef.current?.createDataChannel('chat');
+    chatChannel.current = peerConnectionRef.current?.createDataChannel('chat', {
+      negotiated: true,
+      id: 1,
+    });
 
     mediaInfoChannel.current?.addEventListener('message', ({ data }) => {
       const mediaInfoArray = JSON.parse(data);

--- a/frontend/src/business/hooks/useHumanChat/useHumanChatMessage.ts
+++ b/frontend/src/business/hooks/useHumanChat/useHumanChatMessage.ts
@@ -1,5 +1,5 @@
 import useChatMessage from '../useChatMessage';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function useHumanChatMessage(
   chatChannel: React.MutableRefObject<RTCDataChannel | undefined>,
@@ -7,6 +7,7 @@ export default function useHumanChatMessage(
   setTarotId: (tarotId: number | undefined) => void,
 ) {
   const { messages, pushMessage } = useChatMessage();
+  const [inputDisabled, setInputDisabled] = useState(true);
 
   const addMessage = (type: 'left' | 'right', message: string) => {
     // TODO: host인지에 따라서 프로필 사진을 다르게 해야함
@@ -23,6 +24,14 @@ export default function useHumanChatMessage(
 
   useEffect(() => {
     if (chatChannel.current) {
+      chatChannel.current.addEventListener('open', () => {
+        setInputDisabled(false);
+      });
+
+      chatChannel.current.addEventListener('close', () => {
+        setInputDisabled(true);
+      });
+
       chatChannel.current.addEventListener('message', event => {
         const data = JSON.parse(event.data);
 
@@ -45,5 +54,5 @@ export default function useHumanChatMessage(
     }
   }, [tarotId]);
 
-  return { messages, onSubmitMessage };
+  return { messages, onSubmitMessage, inputDisabled };
 }

--- a/frontend/src/business/hooks/useHumanChat/useHumanChatMessage.ts
+++ b/frontend/src/business/hooks/useHumanChat/useHumanChatMessage.ts
@@ -23,7 +23,7 @@ export default function useHumanChatMessage(
 
   useEffect(() => {
     if (chatChannel.current) {
-      chatChannel.current.onmessage = (event: MessageEvent) => {
+      chatChannel.current.addEventListener('message', event => {
         const data = JSON.parse(event.data);
 
         if (data.type === 'message') {
@@ -33,7 +33,7 @@ export default function useHumanChatMessage(
         if (data.type == 'pickCard') {
           pushMessage({ type: 'right', profile: '/sponge.png', tarotId: data.tarotId });
         }
-      };
+      });
     }
   }, [chatChannel.current]);
 

--- a/frontend/src/business/hooks/useHumanChat/useHumanChatMessage.ts
+++ b/frontend/src/business/hooks/useHumanChat/useHumanChatMessage.ts
@@ -1,6 +1,10 @@
 import useChatMessage from '../useChatMessage';
 import { useEffect, useState } from 'react';
 
+import { HumanChatEvents } from '@constants/events';
+
+const { PICK_CARD, CHAT_MESSAGE } = HumanChatEvents;
+
 export default function useHumanChatMessage(
   chatChannel: React.MutableRefObject<RTCDataChannel | undefined>,
   tarotId: number | undefined,
@@ -18,7 +22,7 @@ export default function useHumanChatMessage(
   const onSubmitMessage = (message: string) => {
     addMessage('right', message);
 
-    const payload = { type: 'message', message };
+    const payload = { type: CHAT_MESSAGE, content: message };
     chatChannel.current?.send(JSON.stringify(payload));
   };
 
@@ -33,14 +37,13 @@ export default function useHumanChatMessage(
       });
 
       chatChannel.current.addEventListener('message', event => {
-        const data = JSON.parse(event.data);
+        const message = JSON.parse(event.data);
 
-        if (data.type === 'message') {
-          addMessage('left', data.message);
+        if (message.type === CHAT_MESSAGE) {
+          addMessage('left', message.content);
         }
-
-        if (data.type == 'pickCard') {
-          pushMessage({ type: 'right', profile: '/sponge.png', tarotId: data.tarotId });
+        if (message.type == PICK_CARD) {
+          pushMessage({ type: 'right', profile: '/sponge.png', tarotId: message.content });
         }
       });
     }

--- a/frontend/src/business/hooks/useHumanChat/useHumanTarotSpread.ts
+++ b/frontend/src/business/hooks/useHumanChat/useHumanTarotSpread.ts
@@ -15,7 +15,7 @@ export default function useHumanTarotSpread(
     setTarotId(idx);
   };
 
-  const requestTarotCard = () => {
+  const requestTarotSpread = () => {
     const payload = { type: TAROT_SPREAD };
     chatChannel.current?.send(JSON.stringify(payload));
   };
@@ -34,5 +34,5 @@ export default function useHumanTarotSpread(
     }
   }, []);
 
-  return { requestTarotCard };
+  return { requestTarotSpread };
 }

--- a/frontend/src/business/hooks/useHumanChat/useHumanTarotSpread.ts
+++ b/frontend/src/business/hooks/useHumanChat/useHumanTarotSpread.ts
@@ -20,13 +20,13 @@ export default function useHumanTarotSpread(
 
   useEffect(() => {
     if (chatChannel.current) {
-      chatChannel.current.onmessage = (event: MessageEvent) => {
+      chatChannel.current.addEventListener('message', event => {
         const data = JSON.parse(event.data);
 
         if (data.type === 'tarotCard') {
           setTimeout(openTarotSpread, 1000);
         }
-      };
+      });
     }
   }, []);
 

--- a/frontend/src/business/hooks/useHumanChat/useHumanTarotSpread.ts
+++ b/frontend/src/business/hooks/useHumanChat/useHumanTarotSpread.ts
@@ -1,18 +1,22 @@
 import { useTarotSpread } from '../useTarotSpread';
 import { useEffect } from 'react';
 
+import { HumanChatEvents } from '@constants/events';
+
+const { PICK_CARD, TAROT_SPREAD } = HumanChatEvents;
+
 export default function useHumanTarotSpread(
   chatChannel: React.MutableRefObject<RTCDataChannel | undefined>,
   setTarotId: (idx: number) => void,
 ) {
   const pickCard = (idx: number) => {
-    const payload = { type: 'pickCard', tarotId: idx };
+    const payload = { type: PICK_CARD, content: idx };
     chatChannel.current?.send(JSON.stringify(payload));
     setTarotId(idx);
   };
 
   const requestTarotCard = () => {
-    const payload = { type: 'tarotCard' };
+    const payload = { type: TAROT_SPREAD };
     chatChannel.current?.send(JSON.stringify(payload));
   };
 
@@ -23,7 +27,7 @@ export default function useHumanTarotSpread(
       chatChannel.current.addEventListener('message', event => {
         const data = JSON.parse(event.data);
 
-        if (data.type === 'tarotCard') {
+        if (data.type === TAROT_SPREAD) {
           setTimeout(openTarotSpread, 1000);
         }
       });

--- a/frontend/src/constants/events.ts
+++ b/frontend/src/constants/events.ts
@@ -1,0 +1,5 @@
+export const HumanChatEvents = {
+  PICK_CARD: 'pickCard',
+  TAROT_SPREAD: 'tarotSpread',
+  CHAT_MESSAGE: 'chatMessage',
+};

--- a/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
+++ b/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Outlet } from 'react-router-dom';
 
@@ -6,6 +7,7 @@ import ChatContainer from '@components/ChatContainer';
 import Header from '@components/Header';
 import SideBar from '@components/SideBar';
 
+import { useHumanChatMessage, useHumanTarotSpread } from '@business/hooks/useHumanChat';
 import { useWebRTC } from '@business/hooks/useWebRTC';
 
 export type OutletContext = ReturnType<typeof useWebRTC>;
@@ -13,6 +15,12 @@ export type OutletContext = ReturnType<typeof useWebRTC>;
 export default function HumanChatPage() {
   const { roomName } = useParams();
   const webRTCData = useWebRTC(roomName as string);
+
+  const [tarotId, setTarotId] = useState<number>();
+
+  // TODO: {requestTarotCard}로 받아 '타로 카드 펼치기' 버튼을 눌렀을 때 실행
+  const {} = useHumanTarotSpread(webRTCData.chatChannel, setTarotId);
+  const { messages, onSubmitMessage } = useHumanChatMessage(webRTCData.chatChannel, tarotId, setTarotId);
 
   return (
     <Background type="dynamic">
@@ -23,10 +31,9 @@ export default function HumanChatPage() {
               width="w-400"
               height="h-4/5"
               position="top-40"
-              // TODO: useHuman~에서 값을 가져와서 넣어주어야 함
-              messages={[]}
+              messages={messages}
               inputDisabled={true}
-              onSubmitMessage={() => {}}
+              onSubmitMessage={onSubmitMessage}
             />
           </SideBar>,
         ]}

--- a/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
+++ b/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
@@ -20,7 +20,7 @@ export default function HumanChatPage() {
 
   // TODO: {requestTarotCard}로 받아 '타로 카드 펼치기' 버튼을 눌렀을 때 실행
   const {} = useHumanTarotSpread(webRTCData.chatChannel, setTarotId);
-  const { messages, onSubmitMessage } = useHumanChatMessage(webRTCData.chatChannel, tarotId, setTarotId);
+  const { messages, onSubmitMessage, inputDisabled } = useHumanChatMessage(webRTCData.chatChannel, tarotId, setTarotId);
 
   return (
     <Background type="dynamic">
@@ -32,8 +32,8 @@ export default function HumanChatPage() {
               height="h-4/5"
               position="top-40"
               messages={messages}
-              inputDisabled={true}
               onSubmitMessage={onSubmitMessage}
+              inputDisabled={inputDisabled}
             />
           </SideBar>,
         ]}

--- a/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
+++ b/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
@@ -18,7 +18,7 @@ export default function HumanChatPage() {
 
   const [tarotId, setTarotId] = useState<number>();
 
-  // TODO: {requestTarotCard}로 받아 '타로 카드 펼치기' 버튼을 눌렀을 때 실행
+  // TODO: {requestTarotSpread}로 받아 '타로 카드 펼치기' 버튼을 눌렀을 때 실행
   const {} = useHumanTarotSpread(webRTCData.chatChannel, setTarotId);
   const { messages, onSubmitMessage, inputDisabled } = useHumanChatMessage(webRTCData.chatChannel, tarotId, setTarotId);
 


### PR DESCRIPTION
resolve #261

### 변경 사항
- WebRTC의 데이터 채널을 사용해 채팅을 주고 받는 기능 구현

### 고민과 해결 과정

**1️⃣ useWebRTC()의 반환 값 중  `chatChannel`을 사용해서 HumanChatPage 채팅 기능 hook을 연결함**

```typescript
export default function HumanChatPage() {
  const { roomName } = useParams();
  const webRTCData = useWebRTC(roomName as string);

  const [tarotId, setTarotId] = useState<number>();

  // TODO: {requestTarotCard}로 받아 '타로 카드 펼치기' 버튼을 눌렀을 때 실행
  const {} = useHumanTarotSpread(webRTCData.chatChannel, setTarotId);
  const { messages, onSubmitMessage, inputDisabled } = useHumanChatMessage(webRTCData.chatChannel, tarotId, setTarotId);

  return (
    <Background type="dynamic">
      <Header
        rightItems={[
          <SideBar key="chat-side-bar">
            <ChatContainer
              width="w-400"
              height="h-4/5"
              position="top-40"
              messages={messages}
              onSubmitMessage={onSubmitMessage}
              inputDisabled={inputDisabled}
            />
          </SideBar>,
        ]}
      />
      <Outlet context={webRTCData} />
    </Background>
  );
}
```

**2️⃣ onmessage => addEventListener("message", ~) 로 변경함**

- onmessage는 여러 개 이벤트 등록이 안됨. 
- message 이벤트 등록을 `useHumanTarotSpread`과 `useHumanChatMessage`에서 나눠서 하기 때문에 addEventListener 방식으로 수정함.

**3️⃣ 메세지를 자꾸 못받는 오류 해결**

수정 전
```typescript
 chatChannel.current = peerConnectionRef.current?.createDataChannel('chat');
```

수정 후
```typescript
 chatChannel.current = peerConnectionRef.current?.createDataChannel('chat', {
    negotiated: true,
    id: 1,
 });
```
- negotiated를 추가해야 오류가 해결되는 이유는 기술 블로그에 정리해 둘 예정


### (선택) 테스트 결과
![녹화_2023_11_29_15_46_57_270](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/03539842-28ad-4e3c-8b8e-a3f62667d25f)