### PR TITLE
Fe/feature/#63#83 호스트가 종료시 방 닫힘

### DIFF
--- a/backend/signal/src/events.js
+++ b/backend/signal/src/events.js
@@ -1,0 +1,62 @@
+import { v4 } from 'uuid';
+
+const socketRooms = {};
+const users = {};
+const MAXIMUM = 2;
+
+export function createRoom(socket, password) {
+  // const roomID = v4();
+  // 테스트용으로 roomID를 1로 고정, 완료되면 위의 코드로 변경
+  const roomID = '1';
+
+  socketRooms[roomID] = { users: [socket.id], password: password };
+
+  users[socket.id] = { roomID, role: 'host' };
+  socket.join(roomID);
+  socket.emit('roomCreated', roomID);
+
+  console.log('room created: ', roomID, password, socketRooms);
+}
+
+export function joinRoom(socket, roomID, password) {
+  const existRoom = socketRooms[roomID];
+  const wrongPassword = socketRooms[roomID].password !== password;
+  if (!existRoom || wrongPassword) {
+    socket.emit('joinRoomFailed');
+    console.log('joinRoomFailed', roomID, password);
+    return;
+  }
+
+  const fullRoom = socketRooms[roomID].users.length === MAXIMUM;
+  if (fullRoom) {
+    socket.emit('roomFull');
+    console.log('rommFull', socketRooms, roomID);
+    return;
+  }
+
+  socketRooms[roomID].users.push(socket.id);
+  users[socket.id] = { roomID, role: 'guest' };
+  socket.join(roomID);
+
+  const ohterUsers = socketRooms[roomID].users.filter(userID => userID !== socket.id);
+  socket.to(roomID).emit('welcome', ohterUsers);
+
+  socket.emit('joinRoomSuccess', roomID);
+}
+
+export function disconnectSocket(socket) {
+  const roomID = users[socket.id];
+
+  if (socketRooms[roomID]) {
+    socketRooms[roomID].users = socketRooms[roomID].users.filter(userID => userID !== socket.id);
+
+    if (socketRooms[roomID].users.length === 0) {
+      delete socketRooms[roomID];
+      return;
+    }
+  }
+  delete users[roomID];
+
+  socket.to(roomID).emit('userExit', { id: socket.id });
+  console.log('exit user: ', socketRooms, roomID);
+}

--- a/backend/signal/src/events.js
+++ b/backend/signal/src/events.js
@@ -5,9 +5,7 @@ const users = {};
 const MAXIMUM = 2;
 
 export function createRoom(socket, password) {
-  // const roomID = v4();
-  // 테스트용으로 roomID를 1로 고정, 완료되면 위의 코드로 변경
-  const roomID = '1';
+  const roomID = v4();
   const userID = socket.id;
 
   socketRooms[roomID] = { users: [userID], password: password };

--- a/backend/signal/src/server.js
+++ b/backend/signal/src/server.js
@@ -1,0 +1,33 @@
+import express from 'express';
+import http from 'http';
+import { Server } from 'socket.io';
+import { createRoom, disconnectSocket, joinRoom } from './events.js';
+
+const app = express();
+
+const server = http.createServer(app);
+
+const io = new Server(server, {
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST'],
+    allowedHeaders: ['my-custom-header'],
+    credentials: true,
+  },
+});
+
+const PORT = 3001;
+
+io.on('connection', socket => {
+  socket.on('offer', (sdp, roomName) => socket.to(roomName).emit('offer', sdp));
+  socket.on('answer', (sdp, roomName) => socket.to(roomName).emit('answer', sdp));
+  socket.on('candidate', (candidate, roomName) => socket.to(roomName).emit('candidate', candidate));
+
+  socket.on('createRoom', password => createRoom(socket, password));
+  socket.on('joinRoom', (roomID, password) => joinRoom(socket, roomID, password));
+  socket.on('disconnect', () => disconnectSocket(socket));
+});
+
+server.listen(PORT, () => {
+  console.log(`server running on ${PORT}`);
+});

--- a/frontend/src/business/hooks/useControllMedia.ts
+++ b/frontend/src/business/hooks/useControllMedia.ts
@@ -15,7 +15,13 @@ export function useControllMedia({
   mediaInfoChannel,
   getMedia,
 }: useContorollMediaProps) {
-  const { toggleMyVideo, toggleMyMic, setSelectedAudioID, setSelectedCameraID } = useMediaInfoContext();
+  const {
+    toggleMyVideo,
+    toggleMyMic,
+    setSelectedAudioID,
+    setSelectedCameraID,
+    mediaInfos: { selectedAudioID, selectedCameraID },
+  } = useMediaInfoContext();
 
   const addTracks = () => {
     if (localStreamRef.current === undefined) {
@@ -66,15 +72,19 @@ export function useControllMedia({
     );
   };
 
-  const changeMyVideoTrack = async (id: string) => {
-    setSelectedCameraID(id);
-    await getMedia({ cameraID: id });
+  const changeMyVideoTrack = async (id?: string) => {
+    const cameraID = id || selectedCameraID;
+
+    setSelectedCameraID(cameraID);
+    await getMedia({ cameraID });
     changeVideoTrack();
   };
 
-  const changeMyAudioTrack = async (id: string) => {
-    setSelectedAudioID(id);
-    await getMedia({ audioID: id });
+  const changeMyAudioTrack = async (id?: string) => {
+    const audioID = id || selectedAudioID;
+
+    setSelectedAudioID(audioID);
+    await getMedia({ audioID: audioID });
     changeAudioTrack();
   };
 

--- a/frontend/src/business/hooks/useSignalingSocket.ts
+++ b/frontend/src/business/hooks/useSignalingSocket.ts
@@ -84,11 +84,13 @@ export function useSignalingSocket({ peerConnectionRef, negotiationDataChannels 
     onFull,
     onFail,
     onSuccess,
+    onHostExit,
   }: {
     roomName: string;
     onFull?: () => void;
     onFail?: () => void;
     onSuccess?: () => void;
+    onHostExit?: () => void;
   }) => {
     openPasswordPopup({
       onClose: () => {
@@ -108,6 +110,10 @@ export function useSignalingSocket({ peerConnectionRef, negotiationDataChannels 
         socketOn('joinRoomSuccess', async () => {
           close();
           onSuccess?.();
+        });
+
+        socketOn('hostExit', () => {
+          onHostExit?.();
         });
       },
     });

--- a/frontend/src/business/hooks/useSocket.ts
+++ b/frontend/src/business/hooks/useSocket.ts
@@ -14,6 +14,7 @@ interface SocketTypesMap {
       | 'candidate'
       | 'roomFull'
       | 'userExit'
+      | 'hostExit'
       | 'roomCreated'
       | 'joinRoomFailed'
       | 'joinRoomSuccess'

--- a/frontend/src/business/hooks/useWebRTC.ts
+++ b/frontend/src/business/hooks/useWebRTC.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { useControllMedia } from './useControllMedia';
 import { useDataChannel } from './useDataChannel';
 import { useMedia } from './useMedia';
@@ -7,7 +9,7 @@ import { useSignalingSocket } from './useSignalingSocket';
 import { useSocket } from './useSocket';
 
 export function useWebRTC() {
-  const { isSocketConnected } = useSocket('WebRTC');
+  const { isSocketConnected, disconnectSocket, connectSocket } = useSocket('WebRTC');
 
   const { mediaInfos } = useMediaInfoContext();
   const {
@@ -64,6 +66,17 @@ export function useWebRTC() {
       closeDataChannels();
     }
   };
+
+  useEffect(() => {
+    if (!isSocketConnected()) {
+      connectSocket(import.meta.env.VITE_HUMAN_SOCKET_URL);
+    }
+
+    return () => {
+      endWebRTC();
+      disconnectSocket();
+    };
+  }, []);
 
   return {
     cameraOptions,

--- a/frontend/src/business/hooks/useWebRTC.ts
+++ b/frontend/src/business/hooks/useWebRTC.ts
@@ -23,9 +23,10 @@ export function useWebRTC() {
     getCamerasOptions,
   } = useMedia();
 
-  const { peerConnectionRef, makeRTCPeerConnection, closeRTCPeerConnection } = useRTCPeerConnection({
-    remoteVideoRef,
-  });
+  const { peerConnectionRef, makeRTCPeerConnection, closeRTCPeerConnection, isConnectedPeerConnection } =
+    useRTCPeerConnection({
+      remoteVideoRef,
+    });
 
   const { mediaInfoChannel, chatChannel, initDataChannels, closeDataChannels } = useDataChannel({
     peerConnectionRef,
@@ -98,5 +99,6 @@ export function useWebRTC() {
     endWebRTC,
     createRoom,
     joinRoom,
+    isConnectedPeerConnection,
   };
 }

--- a/frontend/src/pages/HumanChatPage/ChattingPage.tsx
+++ b/frontend/src/pages/HumanChatPage/ChattingPage.tsx
@@ -7,14 +7,27 @@ import CamContainer from '@components/CamContainer';
 import type { OutletContext } from './HumanChatPage';
 
 export default function ChattingPage() {
-  const { localVideoRef, remoteVideoRef, toggleVideo, toggleAudio, mediaInfos, startWebRTC, joinRoom }: OutletContext =
-    useOutletContext();
+  const {
+    localVideoRef,
+    remoteVideoRef,
+    toggleVideo,
+    toggleAudio,
+    mediaInfos,
+    startWebRTC,
+    joinRoom,
+    isConnectedPeerConnection,
+    changeMyVideoTrack,
+  }: OutletContext = useOutletContext();
 
   const { roomName } = useParams();
   const { state } = useLocation();
   const navigate = useNavigate();
 
   useEffect(() => {
+    if (isConnectedPeerConnection()) {
+      changeMyVideoTrack();
+      return;
+    }
     startWebRTC({ roomName: roomName as string });
 
     if (!roomName || state?.host) {

--- a/frontend/src/pages/HumanChatPage/ChattingPage.tsx
+++ b/frontend/src/pages/HumanChatPage/ChattingPage.tsx
@@ -17,18 +17,24 @@ export default function ChattingPage() {
   useEffect(() => {
     startWebRTC({ roomName: roomName as string });
 
-    if (roomName && !state?.host) {
-      joinRoom({
-        roomName,
-        onFull: () => {
-          alert('방이 꽉 찼습니다, 첫페이지로 이동합니다.');
-          navigate('/');
-        },
-        onFail: () => {
-          alert('잘못된 링크거나 비밀번호가 틀렸습니다.');
-        },
-      });
+    if (!roomName || state?.host) {
+      return;
     }
+
+    joinRoom({
+      roomName,
+      onFull: () => {
+        alert('방이 꽉 찼습니다, 첫페이지로 이동합니다.');
+        navigate('/');
+      },
+      onFail: () => {
+        alert('잘못된 링크거나 비밀번호가 틀렸습니다.');
+      },
+      onHostExit: () => {
+        navigate('/');
+        alert('호스트가 방을 나갔습니다, 첫페이지로 이동합니다.');
+      },
+    });
   }, []);
 
   return (

--- a/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
+++ b/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
@@ -9,7 +9,6 @@ import Header from '@components/Header';
 import SideBar from '@components/SideBar';
 
 import { useHumanChatMessage, useHumanTarotSpread } from '@business/hooks/useHumanChat';
-import { useSocket } from '@business/hooks/useSocket';
 import { useWebRTC } from '@business/hooks/useWebRTC';
 
 export type OutletContext = ReturnType<typeof useWebRTC>;

--- a/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
+++ b/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
@@ -15,19 +15,15 @@ import { useWebRTC } from '@business/hooks/useWebRTC';
 export type OutletContext = ReturnType<typeof useWebRTC>;
 
 export default function HumanChatPage() {
-  const { connectSocket, disconnectSocket, isSocketConnected } = useSocket('WebRTC');
+  // const { disconnectSocket } = useSocket('WebRTC');
   const webRTCData = useWebRTC();
 
   const { roomName } = useParams();
-  const { state } = useLocation();
+  const location = useLocation();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!isSocketConnected()) {
-      connectSocket(import.meta.env.VITE_HUMAN_SOCKET_URL);
-    }
-
-    if (roomName || !state?.host) {
+    if (roomName || !location.state?.host) {
       return;
     }
 
@@ -36,11 +32,6 @@ export default function HumanChatPage() {
         navigate(roomName, { state: { host: true } });
       },
     });
-
-    return () => {
-      webRTCData.endWebRTC();
-      disconnectSocket();
-    };
   }, []);
 
   const [tarotId, setTarotId] = useState<number>();

--- a/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
+++ b/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
@@ -14,7 +14,6 @@ import { useWebRTC } from '@business/hooks/useWebRTC';
 export type OutletContext = ReturnType<typeof useWebRTC>;
 
 export default function HumanChatPage() {
-  // const { disconnectSocket } = useSocket('WebRTC');
   const webRTCData = useWebRTC();
 
   const { roomName } = useParams();

--- a/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
+++ b/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
@@ -27,13 +27,15 @@ export default function HumanChatPage() {
       connectSocket(import.meta.env.VITE_HUMAN_SOCKET_URL);
     }
 
-    if (!roomName && state?.host) {
-      webRTCData.createRoom({
-        onSuccess: ({ roomName }) => {
-          navigate(roomName, { state: { host: true } });
-        },
-      });
+    if (roomName || !state?.host) {
+      return;
     }
+
+    webRTCData.createRoom({
+      onSuccess: ({ roomName }) => {
+        navigate(roomName, { state: { host: true } });
+      },
+    });
 
     return () => {
       webRTCData.endWebRTC();


### PR DESCRIPTION
### 변경 사항
- 방을 생성한 사람에게 권한 부여
- 게스트가 방을 나가면 그냥 나가짐
- 호스트가 방을 나가면 게스트의 방도 닫힘

### 고민과 해결 과정
#### ➡️ 채팅방 생성시 host 권한 부여
아래와 같이 방을 생성할시 users 객체에 role: 'host'를 추가함으로써 권한을 부여해줌
```js
export function createRoom(socket, password) {
  ...
  users[userID] = { roomID, role: 'host' };
  ...
}
```
그리고 방에 들어올 경우 users 객체에 role: 'guest'를 추가해줌.
```js
export function joinRoom(socket, roomID, password) {
  ...
  users[userID] = { roomID, role: 'guest' };
  ...
```

#### ➡️ 게스트가 방을 나가면 그냥 나가짐
만약 role이 gust인데 방을 나가면 그냥 호스트에게 userExit 이벤트를 전달하고  
다음 연결을 위해 데이터 채널 커넥션을 초기화 시켜줌  
다른 사용자는 기존의 데이터 채널을 사용할 수 없고, 재협상이 필요하기 때문  
```js
export function disconnectSocket(socket) {
 ...
  if (role === 'guest') {
    socketRooms[roomID].users = socketRooms[roomID].users.filter(_userID => _userID !== userID);
    socket.to(roomID).emit('userExit', { id: socket.id });
  }
  ...
}
```
#### ➡️ 호스트가 방을 나가면 게스트의 방도 닫힘
호스트가 방을 나가면 방 자체가 제거 돼야 하기 때문에 delete로 방을제거해줌  
그 후에 클라이언트에 hostExit 이벤트를 보내서 `/` 로 리다이렉션 시켜줌.
```js
export function disconnectSocket(socket) {
  ...
  if (role === 'host') {
    socket.to(roomID).emit('hostExit');
    delete socketRooms[roomID];
  }
  ...
}
```

### (선택) 테스트 결과
https://github.com/boostcampwm2023/web09-MagicConch/assets/43428643/cb16e0ba-6bc9-4f86-b6e2-d740e3fd70df

resolve #63 
resolve #83
resolve #309 
