### PR TITLE
Be/refactor/#318 dto 수정

### DIFF
--- a/backend/was/src/chat/chat.controller.ts
+++ b/backend/was/src/chat/chat.controller.ts
@@ -23,7 +23,7 @@ import {
 import { Request } from 'express';
 import { AuthGuard } from 'src/common/auth/auth.guard';
 import { ChatService } from './chat.service';
-import { ChattingMessageResponseDto } from './dto/chatting-messag-response.dto';
+import { ChattingMessageResponseDto } from './dto/chatting-message-response.dto';
 import { ChattingRoomResponseDto } from './dto/chatting-room-response.dto';
 import { UpdateChattingRoomDto } from './dto/update-chatting-room.dto';
 

--- a/backend/was/src/chat/chat.service.ts
+++ b/backend/was/src/chat/chat.service.ts
@@ -8,7 +8,7 @@ import { ERR_MSG } from 'src/common/constants/errors';
 import { LoggerService } from 'src/logger/logger.service';
 import { Member } from 'src/members/entities/member.entity';
 import { QueryFailedError, Repository } from 'typeorm';
-import { ChattingMessageResponseDto } from './dto/chatting-messag-response.dto';
+import { ChattingMessageResponseDto } from './dto/chatting-message-response.dto';
 import { ChattingRoomResponseDto } from './dto/chatting-room-response.dto';
 import { CreateChattingMessageDto } from './dto/create-chatting-message.dto';
 import { UpdateChattingRoomDto } from './dto/update-chatting-room.dto';
@@ -111,24 +111,17 @@ export class ChatService {
     const rooms: ChattingRoom[] = await this.chattingRoomRepository.findBy({
       id,
     });
-    return rooms.map((room: ChattingRoom) => {
-      const roomDto: ChattingRoomResponseDto = new ChattingRoomResponseDto();
-      roomDto.id = room.id;
-      roomDto.title = room.title;
-      return roomDto;
-    });
+    return rooms.map((room: ChattingRoom) =>
+      ChattingRoomResponseDto.fromEntity(room),
+    );
   }
 
   async findMessagesById(id: string): Promise<ChattingMessageResponseDto[]> {
     const messages: ChattingMessage[] =
       await this.chattingMessageRepository.findBy({ id });
-    return messages.map((message: ChattingMessage) => {
-      const messageDto = new ChattingMessageResponseDto();
-      messageDto.id = message.id;
-      messageDto.isHost = message.isHost;
-      messageDto.message = message.message;
-      return messageDto;
-    });
+    return messages.map((message: ChattingMessage) =>
+      ChattingMessageResponseDto.fromEntity(message),
+    );
   }
 
   async updateRoom(

--- a/backend/was/src/chat/dto/chatting-message-response.dto.ts
+++ b/backend/was/src/chat/dto/chatting-message-response.dto.ts
@@ -1,16 +1,21 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsString, IsUUID } from 'class-validator';
+import { ChattingMessage } from '../entities/chatting-message.entity';
 
 export class ChattingMessageResponseDto {
   @IsUUID()
   @ApiProperty({ description: '채팅 메시지 ID', required: true })
-  id: string;
+  readonly id: string;
 
   @IsBoolean()
   @ApiProperty({ description: '호스트 여부', required: true })
-  isHost: boolean;
+  readonly isHost: boolean;
 
   @IsString()
   @ApiProperty({ description: '채팅 메시지', required: true })
-  message: string;
+  readonly message: string;
+
+  static fromEntity(entity: ChattingMessage): ChattingMessageResponseDto {
+    return { ...entity };
+  }
 }

--- a/backend/was/src/chat/dto/chatting-room-response.dto.ts
+++ b/backend/was/src/chat/dto/chatting-room-response.dto.ts
@@ -1,12 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsUUID } from 'class-validator';
+import { ChattingRoom } from '../entities/chatting-room.entity';
 
 export class ChattingRoomResponseDto {
   @IsUUID()
   @ApiProperty({ description: '채팅방 ID', required: true })
-  id: string;
+  readonly id: string;
 
   @IsString()
   @ApiProperty({ description: '채팅방 제목', required: true })
-  title: string;
+  readonly title: string;
+
+  static fromEntity(entity: ChattingRoom): ChattingRoomResponseDto {
+    return { ...entity };
+  }
 }

--- a/backend/was/src/chat/dto/create-chatting-message.dto.ts
+++ b/backend/was/src/chat/dto/create-chatting-message.dto.ts
@@ -1,14 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsString, IsUUID } from 'class-validator';
+import { Message } from 'src/events/type';
 
 export class CreateChattingMessageDto {
   @IsUUID()
   @ApiProperty({ description: '채팅방 ID', required: true })
-  roomId: string;
+  readonly roomId: string;
 
   @IsBoolean()
   @ApiProperty({ description: '호스트 여부', required: true })
-  isHost: boolean;
+  readonly isHost: boolean;
 
   @IsString()
   @ApiProperty({
@@ -17,5 +18,13 @@ export class CreateChattingMessageDto {
     maxLength: 1000,
     required: true,
   })
-  message: string;
+  readonly message: string;
+
+  static fromMessage(message: Message): CreateChattingMessageDto {
+    return {
+      roomId: message.roomId,
+      isHost: message.chat.role === 'assistant',
+      message: message.chat.content,
+    };
+  }
 }

--- a/backend/was/src/chat/dto/update-chatting-room.dto.ts
+++ b/backend/was/src/chat/dto/update-chatting-room.dto.ts
@@ -4,5 +4,5 @@ import { IsString } from 'class-validator';
 export class UpdateChattingRoomDto {
   @IsString()
   @ApiProperty({ description: '채팅방 제목', required: true })
-  title: string;
+  readonly title: string;
 }

--- a/backend/was/src/common/constants/etc.ts
+++ b/backend/was/src/common/constants/etc.ts
@@ -1,0 +1,1 @@
+export const BUCKET_URL = 'https://kr.object.ncloudstorage.com/magicconch';

--- a/backend/was/src/events/create-dto-helper.ts
+++ b/backend/was/src/events/create-dto-helper.ts
@@ -1,24 +1,29 @@
 import { CreateChattingMessageDto } from 'src/chat/dto/create-chatting-message.dto';
-import type { Chat } from './type';
+import type { Chat, Message } from './type';
 
-export function chatLog2createChattingMessageDtos(
+export function createChattingMessageDtos(
+  roomId: string,
   chatLog: Chat[],
 ): CreateChattingMessageDto[] {
-  const parsingMessage: CreateChattingMessageDto[] = chatLog
-    .map(chat2MessageDTO)
+  const messages: Message[] = chatLog.map((chat: Chat): Message => {
+    return {
+      roomId: roomId,
+      chat: chat,
+    };
+  });
+  const parsingMessage: CreateChattingMessageDto[] = messages
+    .map(createChattingMessageDto)
     .filter(isCreateChattingMessageDto);
-
   return parsingMessage.slice(0, -2).concat(parsingMessage.slice(-1));
 }
 
-function chat2MessageDTO(message: Chat): CreateChattingMessageDto | undefined {
-  if (message.role === 'system') {
+function createChattingMessageDto(
+  message: Message,
+): CreateChattingMessageDto | undefined {
+  if (message.chat.role === 'system') {
     return undefined;
   }
-  const messageDto: CreateChattingMessageDto = new CreateChattingMessageDto();
-  messageDto.isHost = message.role === 'assistant';
-  messageDto.message = message.content;
-  return messageDto;
+  return CreateChattingMessageDto.fromMessage(message);
 }
 
 function isCreateChattingMessageDto(

--- a/backend/was/src/events/create-dto-helper.ts
+++ b/backend/was/src/events/create-dto-helper.ts
@@ -1,16 +1,5 @@
 import { CreateChattingMessageDto } from 'src/chat/dto/create-chatting-message.dto';
-import { CreateTarotResultDto } from 'src/tarot/dto/create-tarot-result.dto';
 import type { Chat } from './type';
-
-const bucketUrl: string = 'https://kr.object.ncloudstorage.com/magicconch';
-
-export function result2createTarotResultDto(cardIdx: number, result: string) {
-  const createTarotResultDto = new CreateTarotResultDto();
-  createTarotResultDto.cardUrl = `${bucketUrl}/basic/${cardIdx}.jpg`;
-  createTarotResultDto.message = result;
-
-  return createTarotResultDto;
-}
 
 export function chatLog2createChattingMessageDtos(
   chatLog: Chat[],
@@ -23,14 +12,12 @@ export function chatLog2createChattingMessageDtos(
 }
 
 function chat2MessageDTO(message: Chat): CreateChattingMessageDto | undefined {
-  const messageDto = new CreateChattingMessageDto();
-
   if (message.role === 'system') {
     return undefined;
   }
+  const messageDto: CreateChattingMessageDto = new CreateChattingMessageDto();
   messageDto.isHost = message.role === 'assistant';
   messageDto.message = message.content;
-
   return messageDto;
 }
 

--- a/backend/was/src/events/events.gateway.ts
+++ b/backend/was/src/events/events.gateway.ts
@@ -12,6 +12,7 @@ import { Server, Socket } from 'socket.io';
 import { ChatService, ChattingInfo } from 'src/chat/chat.service';
 import { ERR_MSG } from 'src/common/constants/errors';
 import { LoggerService } from 'src/logger/logger.service';
+import { CreateTarotResultDto } from 'src/tarot/dto/create-tarot-result.dto';
 import { TarotService } from 'src/tarot/tarot.service';
 import {
   askTarotCardCandidates,
@@ -19,10 +20,7 @@ import {
   welcomeMessage,
 } from '../common/constants/events';
 import ClovaStudio from './clova-studio';
-import {
-  chatLog2createChattingMessageDtos,
-  result2createTarotResultDto,
-} from './create-dto-helper';
+import { chatLog2createChattingMessageDtos } from './create-dto-helper';
 import { readTokenStream, string2TokenStream } from './stream';
 import type { MySocket } from './type';
 
@@ -172,7 +170,8 @@ export class EventsGateway
     result: string,
   ): Promise<string> {
     try {
-      const createTarotResultDto = result2createTarotResultDto(cardIdx, result);
+      const createTarotResultDto: CreateTarotResultDto =
+        CreateTarotResultDto.fromResult(cardIdx, result);
       return await this.tarotService.createTarotResult(createTarotResultDto);
     } catch (err: unknown) {
       if (err instanceof Error) {

--- a/backend/was/src/events/events.gateway.ts
+++ b/backend/was/src/events/events.gateway.ts
@@ -20,7 +20,7 @@ import {
   welcomeMessage,
 } from '../common/constants/events';
 import ClovaStudio from './clova-studio';
-import { chatLog2createChattingMessageDtos } from './create-dto-helper';
+import { createChattingMessageDtos } from './create-dto-helper';
 import { readTokenStream, string2TokenStream } from './stream';
 import type { MySocket } from './type';
 
@@ -147,7 +147,8 @@ export class EventsGateway
 
   private async saveChatLog(client: MySocket) {
     try {
-      const createChattingMessageDto = chatLog2createChattingMessageDtos(
+      const createChattingMessageDto = createChattingMessageDtos(
+        client.chatRoomId,
         client.chatLog,
       );
       this.chatService.createMessage(

--- a/backend/was/src/events/type.ts
+++ b/backend/was/src/events/type.ts
@@ -1,5 +1,7 @@
 import { Socket } from 'socket.io';
 
+type Role = 'user' | 'system' | 'assistant';
+
 export interface MySocket extends Socket {
   memberId: string;
   chatLog: Chat[];
@@ -8,8 +10,13 @@ export interface MySocket extends Socket {
 }
 
 export type Chat = {
-  role: 'user' | 'system' | 'assistant';
+  role: Role;
   content: string;
+};
+
+export type Message = {
+  roomId: string;
+  chat: Chat;
 };
 
 export type ClovaEvent = {

--- a/backend/was/src/tarot/dto/create-tarot-result.dto.ts
+++ b/backend/was/src/tarot/dto/create-tarot-result.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsUrl } from 'class-validator';
+import { BUCKET_URL } from 'src/common/constants/etc';
 
 export class CreateTarotResultDto {
   /**
@@ -7,9 +8,16 @@ export class CreateTarotResultDto {
    */
   @IsUrl()
   @ApiProperty({ description: '타로 카드 URL', required: true })
-  cardUrl: string;
+  readonly cardUrl: string;
 
   @IsString()
   @ApiProperty({ description: '타로 해설 결과', required: true })
-  message: string;
+  readonly message: string;
+
+  static fromResult(cardNo: number, message: string): CreateTarotResultDto {
+    return {
+      cardUrl: `${BUCKET_URL}/basic/${cardNo}.jpg`,
+      message: message,
+    };
+  }
 }

--- a/backend/was/src/tarot/dto/tarot-card-response.dto.ts
+++ b/backend/was/src/tarot/dto/tarot-card-response.dto.ts
@@ -1,8 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsUrl } from 'class-validator';
+import { BUCKET_URL } from 'src/common/constants/etc';
+import { TarotCard } from '../entities/tarot-card.entity';
 
 export class TarotCardResponseDto {
   @IsUrl()
   @ApiProperty({ description: '타로 카드 이미지 URL', required: true })
-  cardUrl: string;
+  readonly cardUrl: string;
+
+  static fromEntity(entity: TarotCard): TarotCardResponseDto {
+    return { cardUrl: `${BUCKET_URL}/basic/${entity.cardNo}${entity.ext}` };
+  }
 }

--- a/backend/was/src/tarot/dto/tarot-result-response.dto.ts
+++ b/backend/was/src/tarot/dto/tarot-result-response.dto.ts
@@ -1,12 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsUrl } from 'class-validator';
+import { TarotResult } from '../entities/tarot-result.entity';
 
 export class TarotResultResponseDto {
   @IsUrl()
   @ApiProperty({ description: '타로 카드 이미지 URL', required: true })
-  cardUrl: string;
+  readonly cardUrl: string;
 
   @IsString()
   @ApiProperty({ description: '타로 해설 결과', required: true })
-  message: string;
+  readonly message: string;
+
+  static fromEntity(entity: TarotResult): TarotResultResponseDto {
+    return { ...entity };
+  }
 }

--- a/backend/was/src/tarot/tarot.service.ts
+++ b/backend/was/src/tarot/tarot.service.ts
@@ -9,8 +9,6 @@ import { TarotResultResponseDto } from './dto/tarot-result-response.dto';
 import { TarotCard } from './entities/tarot-card.entity';
 import { TarotResult } from './entities/tarot-result.entity';
 
-const bucketUrl = 'https://kr.object.ncloudstorage.com/magicconch';
-
 @Injectable()
 export class TarotService {
   constructor(
@@ -61,10 +59,7 @@ export class TarotService {
       );
       throw new NotFoundException(ERR_MSG.TAROT_CARD_NOT_FOUND);
     }
-    const cardDto = new TarotCardResponseDto();
-    const url: string = `${bucketUrl}/basic/${id}${tarotCard.ext}`;
-    cardDto.cardUrl = url;
-    return cardDto;
+    return TarotCardResponseDto.fromEntity(tarotCard);
   }
 
   async findTarotResultById(id: string): Promise<TarotResultResponseDto> {
@@ -76,9 +71,6 @@ export class TarotService {
       );
       throw new NotFoundException(ERR_MSG.TAROT_RESULT_NOT_FOUND);
     }
-    const resultDto = new TarotResultResponseDto();
-    resultDto.cardUrl = tarotResult.cardUrl;
-    resultDto.message = tarotResult.message;
-    return resultDto;
+    return TarotResultResponseDto.fromEntity(tarotResult);
   }
 }


### PR DESCRIPTION
resolved #318 
### 변경 사항
DTO 생성 방법 변경

### 고민과 해결 과정
지난 주 멘토링 때, DTO의 필드를 일일이 대입하는 것에 대해 피드백을 받았다. 필드를 일일이 대입하게 되면 중간에 필드를 빼먹는 실수를 할 수도 있고, 필드를 변경했을 때 모든 곳에서 이를 수정해야 한다는 문제가 있다. 

따라서 이를 해결하기 위해 DTO 내에 static 메서드를 만들었다. `fromEntity()`로 DTO를 생성하는 생성자 함수를 흉내냈다. 추가적으로 DTO는 데이터 전달용 객체이므로 `readonly`도 붙여줬다. 
```ts
export class ChattingMessageResponseDto {
  @IsUUID()
  @ApiProperty({ description: '채팅 메시지 ID', required: true })
  readonly id: string;

  @IsBoolean()
  @ApiProperty({ description: '호스트 여부', required: true })
  readonly isHost: boolean;

  @IsString()
  @ApiProperty({ description: '채팅 메시지', required: true })
  readonly message: string;

  static fromEntity(entity: ChattingMessage): ChattingMessageResponseDto {
    return { ...entity };
  }
}
```

```diff
  async findMessagesById(id: string): Promise<ChattingMessageResponseDto[]> {
    const messages: ChattingMessage[] =
      await this.chattingMessageRepository.findBy({ id });
-    return messages.map((message: ChattingMessage) => {
-      const messageDto = new ChattingMessageResponseDto();
-      messageDto.id = message.id;
-      messageDto.isHost = message.isHost;
-      messageDto.message = message.message;
-      return messageDto;
-    });
+    return messages.map((message: ChattingMessage) =>
+      ChattingMessageResponseDto.fromEntity(message),
+    );
  }
```
### (선택) 테스트 결과