### PR TITLE
Fe/bugfix/#329 useTOLD 커스텀 이벤트 작동하게 수정

### DIFF
--- a/frontend/src/business/hooks/useAiChat/useAiChatMessage.ts
+++ b/frontend/src/business/hooks/useAiChat/useAiChatMessage.ts
@@ -10,7 +10,7 @@ export function useAiChatMessage(tarotId: number | undefined, setTarotId: (tarot
   const [inputDisabled, setInputDisabled] = useState(true);
   const { socketEmit, socketOn } = useSocket('AIChat');
 
-  const { displayTold } = useTOLD();
+  const { displayTold } = useTOLD('AI');
 
   const addMessage = (type: 'left' | 'right', message: string, button?: MessageButton) => {
     const profile = type == 'left' ? '/moon.png' : '/sponge.png';

--- a/frontend/src/business/hooks/useTOLD.tsx
+++ b/frontend/src/business/hooks/useTOLD.tsx
@@ -1,12 +1,11 @@
 import useOverlay from './useOverlay';
 
-export default function useTOLD() {
-  const event = new Event('TOLD');
-
+export default function useTOLD(event: 'AI' | 'HUMAN') {
+  const global = window as any;
   const { open } = useOverlay();
 
   const displayTold = () => {
-    window.dispatchEvent(event);
+    global.dataLayer.push({ event });
 
     open(({ close }) => {
       const interval = setInterval(() => {


### PR DESCRIPTION
resolve #329 

### 변경 사항
- [told](https://www.told.club/)를 사용할 때 custom event이 제대로 발생하게 수정함.

### 고민과 해결 과정

- told 쪽의 개발자 문서에서 커스텀 이벤트(피드백 폼이 보여지는 조건)를 어떻게 사용해야 하는 지 잘 나와있지 않았음.
![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/e58dcd98-be11-4064-a592-0913cdd4e25c)

- 그래서 개발자 측에 메일을 보냄

![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/2f6089c0-1462-43d0-a302-f66f544e6f72)

- 답변이 왔다..!

![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/691dea39-d7a0-42f4-8110-5ef8509d5d9a)

- 조언해준 대로 수정해주었다 👍

```typescript
import useOverlay from './useOverlay';

export default function useTOLD(event: 'AI' | 'HUMAN') {
  const global = window as any;
  const { open } = useOverlay();

  const displayTold = () => {
    global.dataLayer.push({ event });

    open(({ close }) => {
      const interval = setInterval(() => {
        const container = document.querySelector('#told-container');
        if (container && !container.innerHTML) {
          return;
        }
        close();
        clearInterval(interval);
      }, 1000);

      return (
        <div className="w-h-screen flex-with-center">
          <span className="loading loading-spinner loading-lg"></span>
        </div>
      );
    });
  };

  return { displayTold };
}
```

### (선택) 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.