### PR TITLE
Fe/bugfix/#340 페이지 이동시 비밀번호 재입력

### DIFF
--- a/frontend/src/business/hooks/useSignalingSocket.ts
+++ b/frontend/src/business/hooks/useSignalingSocket.ts
@@ -89,7 +89,7 @@ export function useSignalingSocket({ peerConnectionRef, negotiationDataChannels 
     roomName: string;
     onFull?: () => void;
     onFail?: () => void;
-    onSuccess?: () => void;
+    onSuccess?: ({ close }: { close: () => void }) => void;
     onHostExit?: () => void;
   }) => {
     openPasswordPopup({
@@ -108,8 +108,7 @@ export function useSignalingSocket({ peerConnectionRef, negotiationDataChannels 
         });
 
         socketOn('joinRoomSuccess', async () => {
-          close();
-          onSuccess?.();
+          onSuccess?.({ close });
         });
 
         socketOn('hostExit', () => {

--- a/frontend/src/business/hooks/useWebRTC.ts
+++ b/frontend/src/business/hooks/useWebRTC.ts
@@ -100,5 +100,6 @@ export function useWebRTC() {
     createRoom,
     joinRoom,
     isConnectedPeerConnection,
+    isSocketConnected,
   };
 }

--- a/frontend/src/components/Popup/Popup.tsx
+++ b/frontend/src/components/Popup/Popup.tsx
@@ -7,7 +7,7 @@ interface PopupProps {
   children: React.ReactNode;
 }
 
-export default function Popup({ close, onCancel, onConfirm, children }: PopupProps) {
+export default function Popup({ onCancel, onConfirm, children }: PopupProps) {
   return (
     <div className="w-[100vw] h-[100vh] flex-with-center">
       <div className="surface-content rounded p-16 gap-16">

--- a/frontend/src/components/Popup/Popup.tsx
+++ b/frontend/src/components/Popup/Popup.tsx
@@ -17,7 +17,6 @@ export default function Popup({ close, onCancel, onConfirm, children }: PopupPro
             size="m"
             color="dark"
             onClick={() => {
-              close();
               onCancel?.();
             }}
           >
@@ -27,7 +26,6 @@ export default function Popup({ close, onCancel, onConfirm, children }: PopupPro
             size="m"
             color="active"
             onClick={() => {
-              close();
               onConfirm?.();
             }}
           >

--- a/frontend/src/pages/HumanChatPage/ChattingPage.tsx
+++ b/frontend/src/pages/HumanChatPage/ChattingPage.tsx
@@ -19,6 +19,7 @@ export default function ChattingPage() {
     changeMyVideoTrack,
     tarotButtonClick,
     tarotButtonDisabled,
+    isSocketConnected,
   }: OutletContext = useOutletContext();
 
   const { roomName } = useParams();
@@ -26,7 +27,7 @@ export default function ChattingPage() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (isConnectedPeerConnection()) {
+    if (isConnectedPeerConnection() || isSocketConnected()) {
       changeMyVideoTrack();
       return;
     }
@@ -38,6 +39,9 @@ export default function ChattingPage() {
 
     joinRoom({
       roomName,
+      onSuccess: ({ close }) => {
+        close();
+      },
       onFull: () => {
         alert('방이 꽉 찼습니다, 첫페이지로 이동합니다.');
         navigate('/');

--- a/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
+++ b/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
@@ -24,6 +24,11 @@ export default function HumanChatPage() {
   const navigate = useNavigate();
 
   useEffect(() => {
+    if (!roomName && !location.state?.host) {
+      alert('잘못된 접근입니다.');
+      navigate('/');
+    }
+
     if (roomName || !location.state?.host) {
       return;
     }


### PR DESCRIPTION
### 변경 사항
- Popup 컴포넌트안에서 close 함수를 호출 해주지 않음
- 설정 -> 채팅 페이지 이동해도 패스워드 창이 뜨지 않음

### 고민과 해결 과정
#### Popup 컴포넌트안에서 close 함수를 호출 해주지 않음
Popup은 popup만 띄우고 닫힐지 말지는 밖에서 판단을 해줘야 한다고 생각함.
이전 코드에서는 확인을 눌렀을 때 바로 닫혀서 다른 로직을 처리해 줄 수 없었음.
그래서 confirm 버튼을 눌렀을 때 close 하는 부분을 제거하고, 외부에서 아래처럼 처리해줌
```ts
openPasswordPopup({
  onCancel: () => {
    navigate('/');
  },
  onSubmit: ({ password, close }) => {
    socketOn('joinRoomSuccess', async () => {
      onSuccess?.({ close });
    });
  },
});
```

#### 설정 -> 채팅 페이지 이동해도 패스워드 창이 뜨지 않음
소켓은 정상적인 경로로 접속할 때 연결됨.
그래서 소켓에 연결이 되어있다면 패스워드 창이 뜨지 않도록 함.


### (선택) 테스트 결과
https://github.com/boostcampwm2023/web09-MagicConch/assets/43428643/a5ff9afc-f18f-4853-8af2-9f178a8d9ca4
