### PR TITLE
Fe/bugfix/#386 경로,팝업관련 버그수정

### DIFF
--- a/frontend/src/@types/close.d.ts
+++ b/frontend/src/@types/close.d.ts
@@ -1,0 +1,3 @@
+interface CloseFunc {
+  close: () => void;
+}

--- a/frontend/src/business/hooks/useBlocker.ts
+++ b/frontend/src/business/hooks/useBlocker.ts
@@ -27,8 +27,9 @@ export function useBlocker({ when, onConfirm, onCancel }: useBlockerParams) {
           setBlockedGoBack(false);
           onConfirm?.();
         },
-        onCancel: () => {
+        onCancel: ({ close }) => {
           onCancel?.();
+          close();
         },
       });
       return true;

--- a/frontend/src/business/hooks/usePopup/useExitPopup.tsx
+++ b/frontend/src/business/hooks/usePopup/useExitPopup.tsx
@@ -3,8 +3,8 @@ import useOverlay from '../useOverlay';
 import Popup from '@components/Popup';
 
 interface openExitPopupParams {
-  onConfirm: () => void;
-  onCancel?: () => void;
+  onConfirm: ({ close }: CloseFunc) => void;
+  onCancel?: ({ close }: CloseFunc) => void;
 }
 
 export function useExitPopup() {
@@ -13,9 +13,8 @@ export function useExitPopup() {
   const openExitPopup = ({ onConfirm, onCancel }: openExitPopupParams) => {
     open(({ close }) => (
       <Popup
-        close={close}
-        onConfirm={onConfirm}
-        onCancel={onCancel}
+        onConfirm={() => onConfirm({ close })}
+        onCancel={() => onCancel?.({ close })}
       >
         <div className="flex-with-center flex-col gap-16">
           <div>나갈거야?</div>

--- a/frontend/src/business/hooks/useWebRTC/useWebRTC.ts
+++ b/frontend/src/business/hooks/useWebRTC/useWebRTC.ts
@@ -52,6 +52,9 @@ export default function useWebRTC() {
   });
 
   const startWebRTC = async ({ roomName }: { roomName: string }) => {
+    if (isConnectedPeerConnection()) {
+      return;
+    }
     await getMedia({});
     initSignalingSocket({ roomName });
     makeRTCPeerConnection({ roomName });

--- a/frontend/src/components/Popup/Popup.tsx
+++ b/frontend/src/components/Popup/Popup.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@components/Buttons';
 
 interface PopupProps {
-  close: () => void;
   onCancel?: () => void;
   onConfirm?: () => void;
   children: React.ReactNode;
@@ -16,14 +15,14 @@ export default function Popup({ onCancel, onConfirm, children }: PopupProps) {
           <Button
             size="m"
             color="dark"
-            onClick={() => onCancel?.()}
+            onClick={onCancel}
           >
             취소하기
           </Button>
           <Button
             size="m"
             color="active"
-            onClick={() => onConfirm?.()}
+            onClick={onConfirm}
           >
             확인하기
           </Button>

--- a/frontend/src/pages/HumanChatPage/ChattingPage.tsx
+++ b/frontend/src/pages/HumanChatPage/ChattingPage.tsx
@@ -21,6 +21,7 @@ export default function ChattingPage() {
     changeMyVideoTrack,
     tarotButtonClick,
     tarotButtonDisabled,
+    socketConnected,
   }: OutletContext = useOutletContext();
 
   const { roomName } = useParams();
@@ -35,11 +36,12 @@ export default function ChattingPage() {
   useSpeakerHighlighter(remoteVideoRef);
 
   useEffect(() => {
-    if (isConnectedPeerConnection()) {
+    startWebRTC({ roomName: roomName as string });
+
+    if (isConnectedPeerConnection() || socketConnected) {
       changeMyVideoTrack();
       return;
     }
-    startWebRTC({ roomName: roomName as string });
 
     if (!roomName || state?.host) {
       return;


### PR DESCRIPTION
### 변경 사항
- 팝업 닫기 누를 시 뒤로 가지지 않던 버그 수정
- 프로필 재설정 할 때마다 비밀번호 재입력 하던 버그 수정

### 고민과 해결 과정

### (선택) 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

close #369 
close #374
close #380 
close #386 