### PR TITLE
Fe/bugfix/#372 호스트에게만 타로카드 펼치기 버튼 활성화

### DIFF
--- a/frontend/src/components/CamContainer/CamContainer.tsx
+++ b/frontend/src/components/CamContainer/CamContainer.tsx
@@ -1,6 +1,7 @@
 import { IconButton, IconToggleButton } from '@components/Buttons';
 import CamBox from '@components/CamBox';
 
+import { useHost } from '@stores/zustandStores/useHost';
 import { useMediaInfo } from '@stores/zustandStores/useMediaInfo';
 import { useProfileInfo } from '@stores/zustandStores/useProfileInfo';
 
@@ -37,6 +38,8 @@ export default function CamContainer({
     setRemoteVideoOn: state.setRemoteVideoOn,
   }));
 
+  const { host } = useHost(state => ({ host: state.host }));
+
   return (
     <div className="flex-with-center flex-col gap-80 pt-80 sm:gap-20">
       <div className="flex justify-center gap-64 sm:flex-col sm:gap-20">
@@ -59,14 +62,16 @@ export default function CamContainer({
           defaultNickname="상대방"
         />
       </div>
-      <div className="flex flex-col gap-30 z-10">
-        <IconButton
-          icon="tabler:cards-filled"
-          onClick={tarotButtonClick}
-          disabled={tarotButtonDisabled}
-        >
-          타로 카드 펼치기
-        </IconButton>
+      <div className="flex marker:flex-col gap-30 z-10">
+        {host && (
+          <IconButton
+            icon="tabler:cards-filled"
+            onClick={tarotButtonClick}
+            disabled={tarotButtonDisabled}
+          >
+            타로 카드 펼치기
+          </IconButton>
+        )}
         <div className="z-10 flex-with-center gap-48">
           <IconToggleButton
             activeIcon="pepicons-pop:camera"

--- a/frontend/src/components/CamContainer/CamContainer.tsx
+++ b/frontend/src/components/CamContainer/CamContainer.tsx
@@ -62,7 +62,7 @@ export default function CamContainer({
           defaultNickname="상대방"
         />
       </div>
-      <div className="flex marker:flex-col gap-30 z-10">
+      <div className="flex-with-center flex-col gap-30 z-10">
         {host && (
           <IconButton
             icon="tabler:cards-filled"

--- a/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
+++ b/frontend/src/pages/HumanChatPage/HumanChatPage.tsx
@@ -12,6 +12,8 @@ import { useHumanChatMessage } from '@business/hooks/useChatMessage';
 import { useHumanTarotSpread } from '@business/hooks/useTarotSpread';
 import useWebRTC from '@business/hooks/useWebRTC';
 
+import { useHost } from '@stores/zustandStores/useHost';
+
 export interface OutletContext extends ReturnType<typeof useWebRTC> {
   tarotButtonClick: () => void;
   tarotButtonDisabled: boolean;
@@ -22,6 +24,8 @@ export default function HumanChatPage() {
   const navigate = useNavigate();
   const webRTCData = useWebRTC();
   const { roomName } = useParams();
+
+  const { setHost } = useHost(state => ({ setHost: state.setHost }));
 
   useEffect(() => {
     if (!roomName && !location.state?.host) {
@@ -36,6 +40,7 @@ export default function HumanChatPage() {
     webRTCData.createRoom({
       onSuccess: ({ roomName, close }) => {
         close();
+        setHost(true);
         navigate(roomName, { state: { host: true } });
       },
       onClose: ({ close }) => {

--- a/frontend/src/stores/zustandStores/useHost.ts
+++ b/frontend/src/stores/zustandStores/useHost.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+interface HostState {
+  host: boolean;
+}
+
+interface HostActions {
+  setHost: (value: boolean) => void;
+}
+
+const initialState: HostState = {
+  host: false,
+};
+
+export const useHost = create<HostState & HostActions>()(
+  devtools(set => ({
+    ...initialState,
+    setHost: (value: boolean) => set(() => ({ host: value })),
+  })),
+);


### PR DESCRIPTION
### 변경 사항
- zustand를 활용해 host 여부 상태를 관리하도록 `useHost` 작성
- host에게만 타로 카드 펼치기 버튼 보여주기

### 고민과 해결 과정

#### 1️⃣ zustand로 useHost 작성

```typescript
import { create } from 'zustand';
import { devtools } from 'zustand/middleware';

interface HostState {
  host: boolean;
}

interface HostActions {
  setHost: (value: boolean) => void;
}

const initialState: HostState = {
  host: false,
};

export const useHost = create<HostState & HostActions>()(
  devtools(set => ({
    ...initialState,
    setHost: (value: boolean) => set(() => ({ host: value })),
  })),
);
```

### 2️⃣ 방 생성할 때 setHost(true) 설정하기


```typescript
const { setHost } = useHost(state => ({ setHost: state.setHost }));
  
...

webRTCData.createRoom({
      onSuccess: ({ roomName, close }) => {
        close();
        setHost(true);
```

#### 3️⃣ 호스트에게만 타로카드 펼치기 버튼 보여주기

```tsx
const { host } = useHost(state => ({ host: state.host }));

...

{host && (
  <IconButton
    icon="tabler:cards-filled"
    onClick={tarotButtonClick}
    disabled={tarotButtonDisabled}
  >
    타로 카드 펼치기
  </IconButton>
)}
```
### (선택) 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.