### PR TITLE
Be/feature/#362 stun/turn 서버 구현

### DIFF
--- a/backend/Dockerfile.signal
+++ b/backend/Dockerfile.signal
@@ -1,5 +1,7 @@
 FROM node:20
 
+RUN apt-get update && apt-get install -y tini
+
 WORKDIR /app
 
 COPY signal ./signal
@@ -9,4 +11,4 @@ WORKDIR /app/signal
 RUN npm install
 RUN npm run build
 
-CMD ["npm", "run", "start:prod"]
+CMD ["tini", "--", "npm", "run", "start:prod"]

--- a/backend/Dockerfile.was
+++ b/backend/Dockerfile.was
@@ -1,5 +1,7 @@
 FROM node:20
 
+RUN apt-get update && apt-get install -y tini
+
 WORKDIR /app
 
 COPY was ./was
@@ -9,4 +11,4 @@ WORKDIR /app/was
 RUN npm install
 RUN npm run build
 
-CMD ["npm", "run", "start:prod"]
+CMD ["tini", "--", "npm", "run", "start:prod"]

--- a/backend/config/nginx/default.conf
+++ b/backend/config/nginx/default.conf
@@ -7,6 +7,20 @@ server {
         root /var/www/certbot;
     }
 
+    location /turn {
+        proxy_pass http://coturn-server:3478;
+        proxy_redirect default;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $server_name;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
     location /signal {
         proxy_pass http://signal-blue:3001;
         proxy_redirect default;
@@ -47,6 +61,20 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/was.tarotmilktea.com/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location /turn {
+        proxy_pass http://coturn-server:3478;
+        proxy_redirect default;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $server_name;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
 
     location /signal {
         proxy_pass http://signal-blue:3001;

--- a/backend/signal/src/main.ts
+++ b/backend/signal/src/main.ts
@@ -15,10 +15,12 @@ async function bootstrap() {
   app.useLogger(logger);
 
   const port: number = parseInt(process.env.PORT || '3001');
-  await app.listen(port);
+  const server: any = await app.listen(port);
 
   process.on('SIGTERM', async () => {
     logger.log('🖐️ Received SIGTERM signal. Start Graceful Shutdown...');
+
+    server.close();
     await app.close();
 
     logger.log('🖐️ Nest Application closed gracefully...');

--- a/backend/signal/src/main.ts
+++ b/backend/signal/src/main.ts
@@ -5,15 +5,24 @@ import { LoggerService } from './logger/logger.service';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  app.useLogger(app.get(LoggerService));
-
   app.enableCors({
     origin: '*',
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
     credentials: true,
   });
 
+  const logger: LoggerService = app.get(LoggerService);
+  app.useLogger(logger);
+
   const port: number = parseInt(process.env.PORT || '3001');
   await app.listen(port);
+
+  process.on('SIGTERM', async () => {
+    logger.log('🖐️ Received SIGTERM signal. Start Graceful Shutdown...');
+    await app.close();
+
+    logger.log('🖐️ Nest Application closed gracefully...');
+    process.exit(0);
+  });
 }
 bootstrap();

--- a/backend/was/src/main.ts
+++ b/backend/was/src/main.ts
@@ -16,11 +16,21 @@ async function bootstrap() {
 
   app.useGlobalPipes(new ValidationPipe());
   app.use(cookieParser());
-  app.useLogger(app.get(LoggerService));
+
+  const logger: LoggerService = app.get(LoggerService);
+  app.useLogger(logger);
 
   setupSwagger(app);
 
   const port: number = parseInt(process.env.PORT || '3000');
   await app.listen(port);
+
+  process.on('SIGTERM', async () => {
+    logger.log('🖐️ Received SIGTERM signal. Start Graceful Shutdown...');
+    await app.close();
+
+    logger.log('🖐️ Nest Application closed gracefully...');
+    process.exit(0);
+  });
 }
 bootstrap();

--- a/backend/was/src/main.ts
+++ b/backend/was/src/main.ts
@@ -23,10 +23,12 @@ async function bootstrap() {
   setupSwagger(app);
 
   const port: number = parseInt(process.env.PORT || '3000');
-  await app.listen(port);
+  const server: any = await app.listen(port);
 
   process.on('SIGTERM', async () => {
     logger.log('🖐️ Received SIGTERM signal. Start Graceful Shutdown...');
+
+    server.close();
     await app.close();
 
     logger.log('🖐️ Nest Application closed gracefully...');


### PR DESCRIPTION
resolved #362 

### 변경 사항
- STUN/TURN 서버 라우팅을 위해 nginx 설정 파일 수정
- graceful shutdown을 위한 설정 추가

<br>

### 고민과 해결 과정
coturn이라는 오픈소스를 활용하여 STUN/TURN 서버를 구축했다. 
> [!NOTE]
> coturn은 NAT 환경에서의 P2P 통신을 돕기 위한 클라이언트 간 데이터 전달 (= TURN) 및 공인 IP와 포트 정보를 제공 (=STUN) 한다.

#### 1️⃣ coturn 도커 컨테이너 띄우기 

현재 서버용 인스턴스를 하나만 이용하고 있기 때문에 서버에게 독립적인 공간을 제공하기 위해 도커 컨테이너로 띄우기로 결정했다. (프로젝트 일관성도 한 몫함..)

도커 컨테이너를 띄우기 전에 coturn 이미지를 다운로드 한다.
```bash
docker pull coturn/coturn
``` 

다음 명령어로 `coturn-server` 컨테이너를 띄운다. 이때, `expose`를 사용하여 nginx 컨테이너를 통한 접속만 허용한다. (외부에서 포트번호로 직접 접속 불가!!) 보안을 위해 `USER`와 `PASSWORD`도 작성해줬다.

```
docker run -d
--expose 3478 \
--name coturn-server \
-e TURN_SERVER_NAME=[server_name] \
-e TURN_SERVER_USER=[server_user] \
-e TURN_SERVER_PASSWORD=[server_password] \
coturn/coturn
```

```
CONTAINER ID   IMAGE                  COMMAND                  CREATED             STATUS             PORTS                                      NAMES
c72a55fa320c   coturn/coturn          "docker-entrypoint.s…"   About an hour ago   Up About an hour   3478/tcp, 3478/udp, 5349/tcp, 5349/udp     coturn-server
```

#### 2️⃣ nginx에서 coturn으로 접속하기

STUN/TURN 서버로 접속하는 url을 `https://was.tarotmilktea.com/turn`으로 지정했다. `/turn` path로 요청이 오면 coturn-server 컨테이너로 프록시한다.

```diff
server {
    ...
+    location /turn {
+        proxy_pass http://coturn-server:3478;
+        proxy_redirect default;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $server_name;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
    ...
}
```

---

사용자 요청을 처리하는 도중에 서버가 무중단 배포 등의 이유로 종료된다면 데이터 손실이 발생할 수 있다. 사용자 경험을 향상시키고 데이터 손실을 막기 위해 graceful shutdown이 필요하다.

> [!NOTE]
> Graceful Shutdown은 서버나 어플리케이션을 정상적으로 종료하거나 다시 시작할 때 진행중인 작업을 마무리하고 새로운 요청을 더 이상 받지 않고 기존 요청을 완료한 후 종료하는 것을 말한다.

graceful shutdown은 현재 처리 중인 요청을 완료하기 위해 충분한 시간을 확보하여 사용자 경험을 향상시키고, 갑작스러운 종료로 인해 심각한 데이터 손실로 이어지는 것을 방지한다. 

nginx는 기본적으로 graceful shutdown을 지원하고 있기 때문에 nest 어플리케이션에 적절한 처리를 해주어야 한다.

```ts
async function bootstrap() {
  const app = await NestFactory.create(AppModule);
  ...
  process.on('SIGTERM', async () => {
    logger.log('🖐️ Received SIGTERM signal. Start Graceful Shutdown...');

    server.close(); // 새로운 요청 받지 못하도록 서버 닫음
    await app.close(); // 요청 끝날 때까지 대기

    logger.log('🖐️ Nest Application closed gracefully...');
    process.exit(0);
  });
}
bootstrap();
```

### (선택) 테스트 결과