### PR TITLE
FE/bugfix/#376-팝업-위에-팝업이-뜨게-되면-팝업이-겹침

### DIFF
--- a/frontend/src/components/Popup/Popup.tsx
+++ b/frontend/src/components/Popup/Popup.tsx
@@ -9,7 +9,7 @@ interface PopupProps {
 export default function Popup({ onCancel, onConfirm, children }: PopupProps) {
   return (
     <div className="w-[100vw] h-[100vh] flex-with-center">
-      <div className="surface-content rounded p-16 gap-16">
+      <div className="surface-content rounded p-16 gap-16 shadow-popup">
         <div className="flex-with-center p-16 display-bold16">{children}</div>
         <div className="flex justify-around p-12 gap-16">
           <Button


### PR DESCRIPTION
resolve #376

### 변경 사항
- 팝업 위에 팝업이 뜨게 되면 팝업이 겹쳐서 이상하게 보이는 문제 수정

### 고민과 해결 과정
- `shadow-popup` 속성이 누락되어 있었다. 다시 추가해 줌.

### (선택) 테스트 결과
![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/dda3bb20-3cc6-472c-b8c8-c7102f1486a9)