### PR TITLE
Be/bugfix/#401 깃헙 액션 배포 이슈

### DIFF
--- a/.github/workflows/blue-green-cd.yml
+++ b/.github/workflows/blue-green-cd.yml
@@ -63,7 +63,6 @@ jobs:
           overwrite: true
 
   deploy:
-    timeout-minutes: 30
     needs: build
     runs-on: ubuntu-latest
 
@@ -84,4 +83,4 @@ jobs:
           script: |
             cd ~/app/backend
             chmod +x deploy.sh
-            source deploy.sh
+            source deploy.sh "${{ secrets.DOCKER_USERNAME }}" "${{ github.sha }}"

--- a/.github/workflows/blue-green-cd.yml
+++ b/.github/workflows/blue-green-cd.yml
@@ -20,6 +20,8 @@ jobs:
         run: |
           cd backend
           echo "${{ secrets.ENV_FILE }}" > .env
+          echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" >> .env
+          echo "GITHUB_SHA=${{ github.sha }}" >> .env
           mkdir -p config/nginx/ssl/
           echo "${{ secrets.SSL_OPTIONS }}" > config/nginx/ssl/options-ssl-nginx.conf
           echo "${{ secrets.SSL_FULLCHAIN }}" > config/nginx/ssl/fullchain.pem

--- a/.github/workflows/blue-green-cd.yml
+++ b/.github/workflows/blue-green-cd.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: ["BE/bugfix/#401-깃헙-액션-배포-이슈"]
 
+env:
+  DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+  GITHUB_SHA: ${{ github.sha }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    env:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      GITHUB_SHA: ${{ github.sha }}
 
     steps:
       - name: Checkout code
@@ -83,4 +83,4 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             cd ~/app/backend
-            source deploy.sh "${{ secrets.DOCKER_USERNAME }}" "${{ github.sha }}"
+            source deploy.sh "${DOCKER_USERNAME}" "${GITHUB_SHA}"

--- a/.github/workflows/blue-green-cd.yml
+++ b/.github/workflows/blue-green-cd.yml
@@ -2,7 +2,7 @@ name: Blue/Green CD
 
 on:
   push:
-    branches: ["BE/bugfix/#401-깃헙-액션-배포-이슈"]
+    branches: ["dev"]
 
 env:
   DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -85,4 +85,4 @@ jobs:
           script: |
             cd ~/app/backend
             chmod +x deploy.sh
-            source deploy.sh "${{ secrets.DOCKER_USERNAME }}" "${{ github.sha }}"
+            source deploy.sh

--- a/.github/workflows/blue-green-cd.yml
+++ b/.github/workflows/blue-green-cd.yml
@@ -8,6 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      GITHUB_SHA: ${{ github.sha }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -33,17 +37,15 @@ jobs:
           target: "~/app/"
           overwrite: true
 
-      - name: Login to Docker Hub
+      - name: Build & Push Docker Images (Blue & Green)
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-      - name: Build & Push Docker Images (Blue & Green)
         run: |
           cd backend
-          docker-compose -f docker-compose.blue.yml build -t "${{ secrets.DOCKER_USERNAME }}/magicconch:blue-${{ github.sha }}"
-          docker-compose -f docker-compose.green.yml build -t "${{ secrets.DOCKER_USERNAME }}/magicconch:green-${{ github.sha }}"
+          docker-compose -f docker-compose.blue.yml build
+          docker-compose -f docker-compose.green.yml build
           docker-compose -f docker-compose.blue.yml push
           docker-compose -f docker-compose.green.yml push
 

--- a/.github/workflows/blue-green-cd.yml
+++ b/.github/workflows/blue-green-cd.yml
@@ -2,7 +2,7 @@ name: Blue/Green CD
 
 on:
   push:
-    branches: ["dev", "BE/bugfix/#401-깃헙-액션-배포-이슈"]
+    branches: ["BE/bugfix/#401-깃헙-액션-배포-이슈"]
 
 jobs:
   build:
@@ -36,7 +36,7 @@ jobs:
       - name: Build Docker Images (Blue)
         run: |
           cd backend
-          docker-compose -f docker-compose.blue.yml build --no-cache -t "${{ secrets.DOCKER_USERNAME }}/magicconch:blue-${{ github.sha }}"
+          docker-compose -f docker-compose.blue.yml build -t "${{ secrets.DOCKER_USERNAME }}/magicconch:blue-${{ github.sha }}"
 
       - name: Push Docker Images to Registry (Blue)
         uses: docker/login-action@v3
@@ -48,7 +48,7 @@ jobs:
       - name: Build Docker Images (Green)
         run: |
           cd backend
-          docker-compose -f docker-compose.green.yml build --no-cache -t "${{ secrets.DOCKER_USERNAME }}/magicconch:green-${{ github.sha }}"
+          docker-compose -f docker-compose.green.yml build -t "${{ secrets.DOCKER_USERNAME }}/magicconch:green-${{ github.sha }}"
 
       - name: Push Docker Images to Registry (Green)
         uses: docker/login-action@v3

--- a/.github/workflows/blue-green-cd.yml
+++ b/.github/workflows/blue-green-cd.yml
@@ -83,4 +83,5 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             cd ~/app/backend
-            source deploy.sh "${DOCKER_USERNAME}" "${GITHUB_SHA}"
+            chmod +x deploy.sh
+            source deploy.sh

--- a/.github/workflows/blue-green-cd.yml
+++ b/.github/workflows/blue-green-cd.yml
@@ -2,7 +2,7 @@ name: Blue/Green CD
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["dev", "BE/bugfix/#401-깃헙-액션-배포-이슈"]
 
 jobs:
   build:
@@ -36,30 +36,26 @@ jobs:
       - name: Build Docker Images (Blue)
         run: |
           cd backend
-          docker builder prune -a -f
-          docker system prune -f
-          cp docker-compose.blue.yml docker-compose.${{ github.sha }}.blue.yml
-          docker-compose -f docker-compose.${{ github.sha }}.blue.yml build --no-cache -t "${{ secrets.DOCKER_USERNAME }}/magicconch:latest-blue"
+          docker-compose -f docker-compose.blue.yml build --no-cache -t "${{ secrets.DOCKER_USERNAME }}/magicconch:blue-${{ github.sha }}"
 
       - name: Push Docker Images to Registry (Blue)
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-      - run: docker-compose -f backend/docker-compose.${{ github.sha }}.blue.yml push
+      - run: docker-compose -f backend/docker-compose.blue.yml push
 
       - name: Build Docker Images (Green)
         run: |
           cd backend
-          cp docker-compose.green.yml docker-compose.${{ github.sha }}.green.yml
-          docker-compose -f docker-compose.${{ github.sha }}.green.yml build --no-cache -t "${{ secrets.DOCKER_USERNAME }}/magicconch:latest-green"
+          docker-compose -f docker-compose.green.yml build --no-cache -t "${{ secrets.DOCKER_USERNAME }}/magicconch:green-${{ github.sha }}"
 
       - name: Push Docker Images to Registry (Green)
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-      - run: docker-compose -f backend/docker-compose.${{ github.sha }}.green.yml push
+      - run: docker-compose -f backend/docker-compose.green.yml push
 
       - name: Copy Dockerfiles to Remote Server
         uses: appleboy/scp-action@master
@@ -68,15 +64,9 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
-          source: "backend/docker-compose.${{ github.sha }}.blue.yml,backend/docker-compose.${{ github.sha }}.green.yml,backend/Dockerfile.nginx,backend/Dockerfile.was,backend/Dockerfile.signal"
+          source: "backend/docker-compose.blue.yml,backend/docker-compose.green.yml,backend/Dockerfile.nginx,backend/Dockerfile.was,backend/Dockerfile.signal"
           target: "~/app/"
           overwrite: true
-
-      - name: Remove local docker-compose copied file
-        run: |
-          cd backend
-          rm docker-compose.${{ github.sha }}.blue.yml
-          rm docker-compose.${{ github.sha }}.green.yml
 
   deploy:
     timeout-minutes: 30
@@ -99,4 +89,4 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             cd ~/app/backend
-            source deploy.sh "${{ github.sha }}"
+            source deploy.sh

--- a/.github/workflows/blue-green-cd.yml
+++ b/.github/workflows/blue-green-cd.yml
@@ -33,29 +33,19 @@ jobs:
           target: "~/app/"
           overwrite: true
 
-      - name: Build Docker Images (Blue)
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Build & Push Docker Images (Blue & Green)
         run: |
           cd backend
           docker-compose -f docker-compose.blue.yml build -t "${{ secrets.DOCKER_USERNAME }}/magicconch:blue-${{ github.sha }}"
-
-      - name: Push Docker Images to Registry (Blue)
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-      - run: docker-compose -f backend/docker-compose.blue.yml push
-
-      - name: Build Docker Images (Green)
-        run: |
-          cd backend
           docker-compose -f docker-compose.green.yml build -t "${{ secrets.DOCKER_USERNAME }}/magicconch:green-${{ github.sha }}"
-
-      - name: Push Docker Images to Registry (Green)
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-      - run: docker-compose -f backend/docker-compose.green.yml push
+          docker-compose -f docker-compose.blue.yml push
+          docker-compose -f docker-compose.green.yml push
 
       - name: Copy Dockerfiles to Remote Server
         uses: appleboy/scp-action@master
@@ -89,4 +79,4 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           script: |
             cd ~/app/backend
-            source deploy.sh
+            source deploy.sh "${{ secrets.DOCKER_USERNAME }}" "${{ github.sha }}"

--- a/.github/workflows/blue-green-cd.yml
+++ b/.github/workflows/blue-green-cd.yml
@@ -37,11 +37,13 @@ jobs:
           target: "~/app/"
           overwrite: true
 
-      - name: Build & Push Docker Images (Blue & Green)
+      - name: Docker login
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Build & Push Docker Images (Blue & Green)
         run: |
           cd backend
           docker-compose -f docker-compose.blue.yml build

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -15,7 +15,7 @@ run_docker() {
   DOCKER_COMPOSE_FILE="docker-compose.$RUN_TARGET.yml"
   DOCKER_IMAGE="$DOCKER_USERNAME/magicconch:$RUN_TARGET-$GITHUB_SHA"
 
-  echo "<<< Run docker compose : $DOCKER_IMAGE" >> $DEBUG_LOG
+  echo "<<< Run docker compose : $DOCKER_COMPOSE_FILE" >> $DEBUG_LOG
 
   docker-compose -f "$DOCKER_COMPOSE_FILE" pull
   docker-compose -f "$DOCKER_COMPOSE_FILE" up -d

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-GITHUB_SHA=$1
 MAIN_SCRIPT="src/main.ts"
 DEBUG_LOG="debug.log"
 NPM_PROD="npm run start:prod"
@@ -8,7 +7,7 @@ NPM_PROD="npm run start:prod"
 run_docker() {
   local RUN_TARGET="$1"
 
-  DOCKER_COMPOSE_FILE="docker-compose.$GITHUB_SHA.$RUN_TARGET.yml"
+  DOCKER_COMPOSE_FILE="docker-compose.$RUN_TARGET.yml"
 
   echo "<<< Run docker compose : $DOCKER_COMPOSE_FILE" > $DEBUG_LOG
 

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-DOCKER_USERNAME=$DOCKER_USERNAME
-GITHUB_SHA=$GITHUB_SHA
+DOCKER_USERNAME=$1
+GITHUB_SHA=$2
 MAIN_SCRIPT="src/main.ts"
 DEBUG_LOG="debug.log"
 NPM_PROD="npm run start:prod"

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-DOCKER_USERNAME=$1
-GITHUB_SHA=$2
+DOCKER_USERNAME=$DOCKER_USERNAME
+GITHUB_SHA=$GITHUB_SHA
 MAIN_SCRIPT="src/main.ts"
 DEBUG_LOG="debug.log"
 NPM_PROD="npm run start:prod"

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+DOCKER_USERNAME=$1
+GITHUB_SHA=$2
 MAIN_SCRIPT="src/main.ts"
 DEBUG_LOG="debug.log"
 NPM_PROD="npm run start:prod"
@@ -8,10 +10,11 @@ run_docker() {
   local RUN_TARGET="$1"
 
   DOCKER_COMPOSE_FILE="docker-compose.$RUN_TARGET.yml"
+  DOCKER_IMAGE="$DOCKER_USERNAME/magicconch:$RUN_TARGET-$GITHUB_SHA"
 
   echo "<<< Run docker compose : $DOCKER_COMPOSE_FILE" > $DEBUG_LOG
 
-  docker-compose -f "$DOCKER_COMPOSE_FILE" pull
+  docker-compose -f "$DOCKER_COMPOSE_FILE" pull "$DOCKER_IMAGE"
   docker-compose -f "$DOCKER_COMPOSE_FILE" up -d
 
   echo ">>> Run complete" >> $DEBUG_LOG

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-DOCKER_USERNAME=$1
-GITHUB_SHA=$2
+DOCKER_USERNAME="$1"
+GITHUB_SHA="$2"
 MAIN_SCRIPT="src/main.ts"
 DEBUG_LOG="debug.log"
 NPM_PROD="npm run start:prod"
+
+echo "DOCKER_USERNAME: $DOCKER_USERNAME" > $DEBUG_LOG
+echo "GITHUB_SHA: $GITHUB_SHA" >> $DEBUG_LOG
 
 run_docker() {
   local RUN_TARGET="$1"
@@ -12,7 +15,7 @@ run_docker() {
   DOCKER_COMPOSE_FILE="docker-compose.$RUN_TARGET.yml"
   DOCKER_IMAGE="$DOCKER_USERNAME/magicconch:$RUN_TARGET-$GITHUB_SHA"
 
-  echo "<<< Run docker compose : $DOCKER_COMPOSE_FILE" > $DEBUG_LOG
+  echo "<<< Run docker compose : $DOCKER_COMPOSE_FILE" >> $DEBUG_LOG
 
   docker-compose -f "$DOCKER_COMPOSE_FILE" pull "$DOCKER_IMAGE"
   docker-compose -f "$DOCKER_COMPOSE_FILE" up -d
@@ -60,7 +63,7 @@ blue_green() {
   fi
 }
 
-if docker ps --filter "name=was-blue" --format '{{.ID}}' | grep -E .; then
+if docker ps --filter "name=blue" --format '{{.ID}}' | grep -E .; then
   RUN_TARGET="green"
   STOP_TARGET="blue"
   WAS_RUN_PORT=3002

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -15,9 +15,9 @@ run_docker() {
   DOCKER_COMPOSE_FILE="docker-compose.$RUN_TARGET.yml"
   DOCKER_IMAGE="$DOCKER_USERNAME/magicconch:$RUN_TARGET-$GITHUB_SHA"
 
-  echo "<<< Run docker compose : $DOCKER_COMPOSE_FILE" >> $DEBUG_LOG
+  echo "<<< Run docker compose : $DOCKER_IMAGE" >> $DEBUG_LOG
 
-  docker-compose -f "$DOCKER_COMPOSE_FILE" pull "$DOCKER_IMAGE"
+  docker-compose -f "$DOCKER_COMPOSE_FILE" pull
   docker-compose -f "$DOCKER_COMPOSE_FILE" up -d
 
   echo ">>> Run complete" >> $DEBUG_LOG

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -1,19 +1,13 @@
 #!/bin/bash
 
-DOCKER_USERNAME="$1"
-GITHUB_SHA="$2"
 MAIN_SCRIPT="src/main.ts"
 DEBUG_LOG="debug.log"
 NPM_PROD="npm run start:prod"
-
-echo "DOCKER_USERNAME: $DOCKER_USERNAME" > $DEBUG_LOG
-echo "GITHUB_SHA: $GITHUB_SHA" >> $DEBUG_LOG
 
 run_docker() {
   local RUN_TARGET="$1"
 
   DOCKER_COMPOSE_FILE="docker-compose.$RUN_TARGET.yml"
-  DOCKER_IMAGE="$DOCKER_USERNAME/magicconch:$RUN_TARGET-$GITHUB_SHA"
 
   echo "<<< Run docker compose : $DOCKER_COMPOSE_FILE" >> $DEBUG_LOG
 

--- a/backend/docker-compose.blue.yml
+++ b/backend/docker-compose.blue.yml
@@ -3,6 +3,7 @@ version: "3.3"
 services:
   was-blue:
     image: "${DOCKER_USERNAME}/magicconch:blue-${GITHUB_SHA}"
+    container_name: "was-blue"
     build:
       context: .
       dockerfile: Dockerfile.was
@@ -24,6 +25,7 @@ services:
 
   signal-blue:
     image: "${DOCKER_USERNAME}/magicconch:blue-${GITHUB_SHA}"
+    container_name: "signal-blue"
     build:
       context: .
       dockerfile: Dockerfile.signal
@@ -33,6 +35,7 @@ services:
       - "3001"
 
   nginx:
+    container_name: "nginx-proxy"
     build:
       context: .
       dockerfile: Dockerfile.nginx

--- a/backend/docker-compose.blue.yml
+++ b/backend/docker-compose.blue.yml
@@ -2,6 +2,7 @@ version: "3.3"
 
 services:
   was-blue:
+    image: "${DOCKER_USERNAME}/magicconch:blue-${GITHUB_SHA}"
     build:
       context: .
       dockerfile: Dockerfile.was
@@ -22,6 +23,7 @@ services:
       - /var/log/was:/app/was/logs
 
   signal-blue:
+    image: "${DOCKER_USERNAME}/magicconch:blue-${GITHUB_SHA}"
     build:
       context: .
       dockerfile: Dockerfile.signal

--- a/backend/docker-compose.blue.yml
+++ b/backend/docker-compose.blue.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   was-blue:
-    image: "${DOCKER_USERNAME}/magicconch:blue-${GITHUB_SHA}"
+    image: "${DOCKER_USERNAME}/magicconch:was-blue-${GITHUB_SHA}"
     container_name: "was-blue"
     build:
       context: .
@@ -24,7 +24,7 @@ services:
       - /var/log/was:/app/was/logs
 
   signal-blue:
-    image: "${DOCKER_USERNAME}/magicconch:blue-${GITHUB_SHA}"
+    image: "${DOCKER_USERNAME}/magicconch:signal-blue-${GITHUB_SHA}"
     container_name: "signal-blue"
     build:
       context: .

--- a/backend/docker-compose.green.yml
+++ b/backend/docker-compose.green.yml
@@ -2,6 +2,7 @@ version: "3.3"
 
 services:
   was-green:
+    image: "${DOCKER_USERNAME}/magicconch:green-${GITHUB_SHA}"
     build:
       context: .
       dockerfile: Dockerfile.was
@@ -22,6 +23,7 @@ services:
       - /var/log/was:/app/was/logs
 
   signal-green:
+    image: "${DOCKER_USERNAME}/magicconch:green-${GITHUB_SHA}"
     build:
       context: .
       dockerfile: Dockerfile.signal

--- a/backend/docker-compose.green.yml
+++ b/backend/docker-compose.green.yml
@@ -3,6 +3,7 @@ version: "3.3"
 services:
   was-green:
     image: "${DOCKER_USERNAME}/magicconch:green-${GITHUB_SHA}"
+    container_name: "was-green"
     build:
       context: .
       dockerfile: Dockerfile.was
@@ -24,6 +25,7 @@ services:
 
   signal-green:
     image: "${DOCKER_USERNAME}/magicconch:green-${GITHUB_SHA}"
+    container_name: "signal-green"
     build:
       context: .
       dockerfile: Dockerfile.signal
@@ -33,6 +35,7 @@ services:
       - "3003"
 
   nginx:
+    container_name: "nginx-proxy"
     build:
       context: .
       dockerfile: Dockerfile.nginx

--- a/backend/docker-compose.green.yml
+++ b/backend/docker-compose.green.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   was-green:
-    image: "${DOCKER_USERNAME}/magicconch:green-${GITHUB_SHA}"
+    image: "${DOCKER_USERNAME}/magicconch:was-green-${GITHUB_SHA}"
     container_name: "was-green"
     build:
       context: .
@@ -24,7 +24,7 @@ services:
       - /var/log/was:/app/was/logs
 
   signal-green:
-    image: "${DOCKER_USERNAME}/magicconch:green-${GITHUB_SHA}"
+    image: "${DOCKER_USERNAME}/magicconch:signal-green-${GITHUB_SHA}"
     container_name: "signal-green"
     build:
       context: .


### PR DESCRIPTION
resolved #401 

### 변경 사항
이미지를 삭제하지 않으면 새로운 작업 내역이 반영되지 않는 문제가 발생했다. 이를 해결하기 위해 이미지가 새롭게 생성되는지 봤는데 새롭게 빌드를 해도 기존 이미지가 유지되고 있는 것을 발견했다.

**깃헙 해시를 이미지 태그로 사용하여 버전관리를 하도록 수정!!**

<br>

### 고민과 해결 과정

#### 1️⃣ 방구뿐인 코드

아래는 수정 전의 코드다.
```yml
  run: |
    cd backend
    docker builder prune -a -f
    docker system prune -f
    cp docker-compose.blue.yml docker-compose.${{ github.sha }}.blue.yml
    docker-compose -f docker-compose.${{ github.sha }}.blue.yml build --no-cache -t "${{ secrets.DOCKER_USERNAME }}/magicconch:latest-blue"
```
놀랍게도 저 짧은 코드에 오류가 세 가지나 있다.
1. `docker builder`, `docker system` 필요없다.
2. `--no-cache`도 필요없다.
3. `-t`도 동작하지 않는다.

처음에는 도커 캐시의 문제인 줄 알고 `docker builder prune -a -f` 같은 명령어를 사용했다. `--no-cache`도 썼지만 다 무용지물이었다.

저 코드 자체도 태그를 이용한 버전 관리가 제대로 되진 않지만 `-t`도 동작하지 않는다. docker cli에서 `-t`는 빌드한 이미지에 이름과 태그를 부여한다. 따라서 docker-compose도 똑같을 줄 알았다.

하지만 docker-compose는 별도의 파일로 서비스 정의에 `image`를 지정할 수 있기 때문에  `-t` 옵션이 존재하지 않는다. 😱

#### 2️⃣ 오버라이드도 안돼요

이름과 태그를 지정하지 않으면 디폴트값이 적용되는데, 오버라이드가 안된다. 캐시 없이 빌드해도 오버라이드가 안 되니 작업 내역이 반영되지 않는다.

따라서 이미지의 태그로 버전 관리를 해줘야 한다.

#### 3️⃣ 도커 컴포즈 수정하기

이름과 태그를 지정하기 위해 도커 컴포즈 파일을 수정한다. `image`만 수정하면 되지만 `container_name`도 같이 수정해봤다.
```diff
version: "3.3"

services:
  was-blue:
+    image: "${DOCKER_USERNAME}/magicconch:was-blue-${GITHUB_SHA}"
+    container_name: "was-blue"
    ...

  signal-blue:
+    image: "${DOCKER_USERNAME}/magicconch:signal-blue-${GITHUB_SHA}"
+    container_name: "signal-blue"
    ...

  nginx:
+    container_name: "nginx-proxy"
    ...
..
```

<br>

### (선택) 테스트 결과
버전 관리용 태그가 잘 붙어있고, 서비스별로 이미지가 생성되었다.
![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/70785620/54be1b82-067d-4411-80fe-f0df6303ecad)

