### PR TITLE
FE/bugfix/#404 카메라,오디오 변경 제대로 안됨

### DIFF
--- a/frontend/src/components/Select/Select.tsx
+++ b/frontend/src/components/Select/Select.tsx
@@ -20,7 +20,9 @@ export default function Select({ width, options, autoFocus, onChange }: SelectPr
   const [selected, setSelected] = useState<SelectOptions>({ value: '', label: '' });
 
   useEffect(() => {
-    if (options.length) setSelected(options[0]);
+    if (options.length && !selected.value && !selected.label) {
+      setSelected(options[0]);
+    }
   }, [options]);
 
   const updateOption = (option: SelectOptions) => {


### PR DESCRIPTION
### 변경 사항
- 카메라, 오디오 변경이 제대로 됨

### 고민과 해결 과정
- 미디어 option이 변경 될 때마다 강제로 0번째를 선택하도록 되어있었음..
- 이를 초기에만 수행하도록 변경함
```diff
useEffect(() => {
-  if (options.length) setSelected(options[0]);
+  if (options.length && !selected.value && !selected.label) {
+    setSelected(options[0]);
+  }
}, [options]);
```

### (선택) 테스트 결과

https://github.com/boostcampwm2023/web09-MagicConch/assets/43428643/c949aa79-2a77-4b76-9af8-4bfc092c20bd

