### PR TITLE
Fe/bugfix/#408 speaker highlighter가 소리 인식을 너무 쉽게 하는 문제

### DIFF
--- a/frontend/src/business/hooks/useSpeakerHighlighter.ts
+++ b/frontend/src/business/hooks/useSpeakerHighlighter.ts
@@ -6,6 +6,8 @@ const FFT_SIZE = 32;
 const INTERVAL_TIME = 100;
 const SHADOW_COLOR = '#0052F0';
 const MAX_SHADOW_LENGTH = 70;
+const THERESHSHOLD = 60;
+const MAX_VOLUME = 255;
 
 export default function useSpeakerHighlighter(videoRef: React.RefObject<HTMLVideoElement>) {
   const interval = useRef<NodeJS.Timeout>();
@@ -45,7 +47,6 @@ export default function useSpeakerHighlighter(videoRef: React.RefObject<HTMLVide
       interval.current = setInterval(() => {
         analyser.getByteFrequencyData(dataArray);
         const curVolume = calculateAverage(dataArray);
-
         animateHighLight(videoElement, prevVolume, curVolume);
 
         prevVolume = curVolume;
@@ -56,14 +57,19 @@ export default function useSpeakerHighlighter(videoRef: React.RefObject<HTMLVide
   }, [videoRef.current]);
 }
 
-function animateHighLight(videoElement: HTMLVideoElement, startLength: number, endLength: number) {
+function animateHighLight(videoElement: HTMLVideoElement, startVolume: number, endVolume: number) {
   const frames = [
-    { filter: `drop-shadow(0px 0px ${Math.min(startLength, MAX_SHADOW_LENGTH)}px ${SHADOW_COLOR}` },
-    { filter: `drop-shadow(0px 0px ${Math.min(endLength, MAX_SHADOW_LENGTH)}px ${SHADOW_COLOR}` },
+    { filter: `drop-shadow(0px 0px ${getShadowLength(startVolume)}px ${SHADOW_COLOR}` },
+    { filter: `drop-shadow(0px 0px ${getShadowLength(endVolume)}px ${SHADOW_COLOR}` },
   ];
   const options: KeyframeAnimationOptions = {
     duration: INTERVAL_TIME,
     fill: 'forwards',
   };
   videoElement.animate(frames, options);
+}
+
+function getShadowLength(volume: number) {
+  const thresholdedVolume = Math.max(volume - THERESHSHOLD, 0);
+  return (thresholdedVolume / (MAX_VOLUME - THERESHSHOLD)) * MAX_SHADOW_LENGTH;
 }

--- a/frontend/src/business/hooks/useSpeakerHighlighter.ts
+++ b/frontend/src/business/hooks/useSpeakerHighlighter.ts
@@ -6,7 +6,7 @@ const FFT_SIZE = 32;
 const INTERVAL_TIME = 100;
 const SHADOW_COLOR = '#0052F0';
 const MAX_SHADOW_LENGTH = 70;
-const THERESHSHOLD = 60;
+const THRESHOLD = 60;
 const MAX_VOLUME = 255;
 
 export default function useSpeakerHighlighter(videoRef: React.RefObject<HTMLVideoElement>) {
@@ -70,6 +70,6 @@ function animateHighLight(videoElement: HTMLVideoElement, startVolume: number, e
 }
 
 function getShadowLength(volume: number) {
-  const thresholdedVolume = Math.max(volume - THERESHSHOLD, 0);
-  return (thresholdedVolume / (MAX_VOLUME - THERESHSHOLD)) * MAX_SHADOW_LENGTH;
+  const thresholdedVolume = Math.max(volume - THRESHOLD, 0);
+  return (thresholdedVolume / (MAX_VOLUME - THRESHOLD)) * MAX_SHADOW_LENGTH;
 }

--- a/frontend/src/utils/unit8Array.ts
+++ b/frontend/src/utils/unit8Array.ts
@@ -1,3 +1,3 @@
 export function calculateAverage(array: Uint8Array) {
-  return array.reduce((acc, value) => acc + value, 0);
+  return array.reduce((acc, value) => acc + value, 0) / array.length;
 }


### PR DESCRIPTION
### 변경 사항
- speaker highlighter가 소리 인식을 너무 쉽게 하는 문제 개선

### 고민과 해결 과정

#### 1️⃣  dataArray 평균 계산 함수 수정

더하기만하고 배열 길이대로 나누질 않았다.. 코파일럿만 믿지말고 코드를 꼭 확인하는 습관을 가져야겠다..

#### 2️⃣ 그림자 길이 계산하는 부분 함수로 분리

- 일정 볼륨 이하는 그림자 표시를 하지 않도록 0으로 처리해주었고, 최대 볼륨으로 나누고 최대 그림자 길이로 나눠서 적절한 그림자 길이를 계산해주는 함수를 만들어뒀다.

```typescript
function getShadowLength(volume: number) {
  const thresholdedVolume = Math.max(volume - THERESHSHOLD, 0);
  return (thresholdedVolume / (MAX_VOLUME - THERESHSHOLD)) * MAX_SHADOW_LENGTH;
}
```
### (선택) 테스트 결과
![녹화_2023_12_07_11_46_58_703](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/6f07d9ca-af89-465a-9cd4-50c570908f8a)
