### PR TITLE
Fe/bugfix/#416 #417 host 방에 혼자 있을 때 미디어 toggle 시 에러 들어오기 전의 미디어 상태 반영 안됨

### DIFF
--- a/frontend/src/business/hooks/useWebRTC/useControllMedia.ts
+++ b/frontend/src/business/hooks/useWebRTC/useControllMedia.ts
@@ -55,9 +55,8 @@ export function useControllMedia({
     videoTrack.getVideoTracks().forEach(track => (track.enabled = !track.enabled));
     toggleMyVideo();
     // 여기서 dataChannel로 비디오 on/off를 보내줘야 함
-    mediaInfoChannel.current?.send(
-      JSON.stringify([{ type: 'video', onOrOff: videoTrack.getVideoTracks()[0].enabled }]),
-    );
+    if (!mediaInfoChannel.current || mediaInfoChannel.current.readyState !== 'open') return;
+    mediaInfoChannel.current.send(JSON.stringify([{ type: 'video', onOrOff: videoTrack.getVideoTracks()[0].enabled }]));
   };
 
   const toggleAudio = () => {
@@ -69,9 +68,8 @@ export function useControllMedia({
     audioTrack.getAudioTracks().forEach(track => (track.enabled = !track.enabled));
     toggleMyMic();
     // 여기서 dataChannel로 오디오 on/off를 보내줘야 함
-    mediaInfoChannel.current?.send(
-      JSON.stringify([{ type: 'audio', onOrOff: audioTrack.getAudioTracks()[0].enabled }]),
-    );
+    if (!mediaInfoChannel.current || mediaInfoChannel.current.readyState !== 'open') return;
+    mediaInfoChannel.current.send(JSON.stringify([{ type: 'audio', onOrOff: audioTrack.getAudioTracks()[0].enabled }]));
   };
 
   const changeMyVideoTrack = async (id?: string) => {

--- a/frontend/src/business/hooks/useWebRTC/useControllMedia.ts
+++ b/frontend/src/business/hooks/useWebRTC/useControllMedia.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { useMediaInfo } from '@stores/zustandStores/useMediaInfo';
 
 interface useContorollMediaParams {
@@ -87,6 +89,22 @@ export function useControllMedia({
     await getMedia({ audioID: audioID });
     changeAudioTrack();
   };
+
+  useEffect(() => {
+    if (!mediaInfoChannel.current) return;
+
+    mediaInfoChannel.current.addEventListener('open', () => {
+      const audioTrack = localVideoRef.current?.srcObject as MediaStream;
+      const videoTrack = localVideoRef.current?.srcObject as MediaStream;
+
+      mediaInfoChannel.current?.send(
+        JSON.stringify([{ type: 'audio', onOrOff: audioTrack.getAudioTracks()[0].enabled }]),
+      );
+      mediaInfoChannel.current?.send(
+        JSON.stringify([{ type: 'video', onOrOff: videoTrack.getVideoTracks()[0].enabled }]),
+      );
+    });
+  }, [mediaInfoChannel.current]);
 
   return { addTracks, changeMyVideoTrack, changeMyAudioTrack, toggleVideo, toggleAudio };
 }


### PR DESCRIPTION
### 변경 사항
- host 방에 혼자 있을 때 미디어 toggle 시 발생하는 에러 수정
- 들어오기 전의 미디어 상태 반영 안됨 문제 해결
   (host가 방 생성 -> 카메라나 마이크 킴 -> 상담자가 들어옴 -> host가 카메라/마이크 끈 걸로 인식했음)

### 고민과 해결 과정

#### 1️⃣ 미디어 toggle 시에 data channel 상태가 open이 아니면 early return
```typescript
if (!mediaInfoChannel.current || mediaInfoChannel.current.readyState !== 'open') return;
```

#### 2️⃣ data channel open이 되면 현재 상태를 message로 보내도록 설정

```typescript
useEffect(() => {
    if (!mediaInfoChannel.current) return;

    mediaInfoChannel.current.addEventListener('open', () => {
      const audioTrack = localVideoRef.current?.srcObject as MediaStream;
      const videoTrack = localVideoRef.current?.srcObject as MediaStream;

      mediaInfoChannel.current?.send(
        JSON.stringify([{ type: 'audio', onOrOff: audioTrack.getAudioTracks()[0].enabled }]),
      );
      mediaInfoChannel.current?.send(
        JSON.stringify([{ type: 'video', onOrOff: videoTrack.getVideoTracks()[0].enabled }]),
      );
    });
  }, [mediaInfoChannel.current]);
```