### PR TITLE
Be/bugfix/#414 stun/turn 접근

### DIFF
--- a/backend/config/nginx/default.conf
+++ b/backend/config/nginx/default.conf
@@ -7,20 +7,6 @@ server {
         root /var/www/certbot;
     }
 
-    location /turn {
-        proxy_pass http://coturn-server:3478;
-        proxy_redirect default;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $server_name;
-
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-    }
-
     location /signal {
         proxy_pass http://signal-blue:3001;
         proxy_redirect default;
@@ -61,20 +47,6 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/was.tarotmilktea.com/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-
-    location /turn {
-        proxy_pass http://coturn-server:3478;
-        proxy_redirect default;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $server_name;
-
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-    }
 
     location /signal {
         proxy_pass http://signal-blue:3001;

--- a/backend/docker-compose.blue.yml
+++ b/backend/docker-compose.blue.yml
@@ -36,16 +36,6 @@ services:
     expose:
       - "3001"
 
-  coturn-server:
-    image: "coturn/coturn"
-    container_name: "coturn-server"
-    environment:
-      - TURN_SERVER_NAME=${TURN_SERVER_NAME}
-      - TURN_SERVER_USER=${TURN_SERVER_USER}
-      - TURN_SERVER_PASSWORD=${TURN_SERVER_PASSWORD}
-    expose:
-      - "3478"
-
   nginx:
     container_name: "nginx-reverse-proxy"
     build:
@@ -57,7 +47,6 @@ services:
     depends_on:
       - was-blue
       - signal-blue
-      - coturn-server
       - certbot
     volumes:
       - /var/log/nginx:/var/log/nginx

--- a/backend/docker-compose.green.yml
+++ b/backend/docker-compose.green.yml
@@ -36,16 +36,6 @@ services:
     expose:
       - "3003"
 
-  coturn-server:
-    image: "coturn/coturn"
-    container_name: "coturn-server"
-    environment:
-      - TURN_SERVER_NAME=${TURN_SERVER_NAME}
-      - TURN_SERVER_USER=${TURN_SERVER_USER}
-      - TURN_SERVER_PASSWORD=${TURN_SERVER_PASSWORD}
-    expose:
-      - "3478"
-
   nginx:
     container_name: "nginx-reverse-proxy"
     build:
@@ -57,7 +47,6 @@ services:
     depends_on:
       - was-green
       - signal-green
-      - coturn-server
       - certbot
     volumes:
       - /var/log/nginx:/var/log/nginx


### PR DESCRIPTION
resolved #414 
### 변경 사항
stun/turn 서버를 위한 coturn-server 설정 모두 삭제

### 고민과 해결 과정
nginx의 리버스 프록시를 제대로 활용해보고자 `coturn-server`로 프록시 하는 코드를 추가했었다. 하지만 tcp, http 기반의 nginx가 udp 기반의 stun을 처리하기엔 적합하지 않다.

> [!IMPORTANT]
> **STUN**
> STUN은 P2P 통신을 지원하기 위한 프로토콜로, NAT에서 할당된 공인 IP 주소, 포트 등을 확인하는 데 사용된다.
> STUN은 **UDP (3478)** 를 기반으로 동작한다. 클라이언트가 STUN 서버에게 Binding Request를 보내고, 서버는 Binding Response를 반환한다. 이를 통해 클라이언트는 자신의 NAT 주소를 알 수 있다.
   
coturn을 도커 컨테이너로 띄울까, 아니면 호스트 서버에 바로 띄울까 고민하다가 nginx에서 프록시 할 수 없기 때문에 그냥 호스트 서버에 설치하기로 결정했다.

### 호스트 서버에 구축하기
1. coturn 설치

```bash
apt-get update
apt-get install coturn
```

2. 방화벽 설정

VPC 퍼블릭 서브넷, 서버 ACG 설정에 다음 포트들 인바운드 / 아웃바운드 허용하기

```
# 인바운드
TCP    0.0.0.0/0    3478
UDP    0.0.0.0/0    3478
TCP    0.0.0.0/0    5349
UDP    0.0.0.0/0    5349
```

4. `/etc/defulat/coturn` 수정 : `TURN_SERVER_ENABLED=1`

5. `/etc/turnserver.conf` 작성 & turn 서버 재시작 : coturn을 turn 서버로 사용하기 위한 설정 파일 작성

```bash
# Coturn TURN SERVER configuration file

# TURN listener port for UDP and TCP (Default: 3478).
# Note: actually, TLS & DTLS sessions can connect to the 
# "plain" TCP & UDP port(s), too - if allowed by configuration.
#
listening-port=3478

# TURN listener port for TLS (Default: 5349).
# Note: actually, "plain" TCP & UDP sessions can connect to the TLS & DTLS
# port(s), too - if allowed by configuration. The TURN server 
# "automatically" recognizes the type of traffic. Actually, two listening
# endpoints (the "plain" one and the "tls" one) are equivalent in terms of
# functionality; but we keep both endpoints to satisfy the RFC 5766 specs.
# For secure TCP connections, we currently support SSL version 3 and 
# TLS version 1.0, 1.1 and 1.2.
# For secure UDP connections, we support DTLS version 1.
#
tls-listening-port=5349

# Listener IP address of relay server. Multiple listeners can be specified.
# If no IP(s) specified in the config file or in the command line options,
# then all IPv4 and IPv6 system IPs will be used for listening.
#
#listening-ip=10.207.21.238
#listening-ip=2607:f0d0:1002:51::4

# For Amazon EC2 users:
#
# TURN Server public/private address mapping, if the server is behind NAT.
# In that situation, if a -X is used in form "-X <ip>" then that ip will be reported
# as relay IP address of all allocations. This scenario works only in a simple case
# when one single relay address is be used, and no RFC5780 functionality is required.
# That single relay address must be mapped by NAT to the 'external' IP.
# The "external-ip" value, if not empty, is returned in XOR-RELAYED-ADDRESS field.
# For that 'external' IP, NAT must forward ports directly (relayed port 12345
# must be always mapped to the same 'external' port 12345).
#
# In more complex case when more than one IP address is involved,
# that option must be used several times, each entry must
# have form "-X <public-ip/private-ip>", to map all involved addresses.
# RFC5780 NAT discovery STUN functionality will work correctly,
# if the addresses are mapped properly, even when the TURN server itself
# is behind A NAT.
#
# By default, this value is empty, and no address mapping is used.
#
external-ip=[public_ip]/[private_ip]

# Uncomment to run TURN server in 'normal' 'moderate' verbose mode.
# By default the verbose mode is off.
verbose

# Uncomment to use fingerprints in the TURN messages.
# By default the fingerprints are off.
#
fingerprint

# Uncomment to use long-term credential mechanism.
# By default no credentials mechanism is used (any user allowed).
#
lt-cred-mech

# 'Static' user accounts for the long term credentials mechanism, only.
# This option cannot be used with TURN REST API.
# 'Static' user accounts are NOT dynamically checked by the turnserver process,
# so they can NOT be changed while the turnserver is running.
#
user=[turn_server_user]:[turn_server_password]
#user=username2:key2
# OR:
#user=username1:password1
#user=username2:password2

# Server name used for
# the oAuth authentication purposes.
# The default value is the realm name.
#
#server-name=blackdow.carleon.gov

log-file=/var/tmp/turn.log

# Option to redirect all log output into system log (syslog).
#
syslog

# This flag means that no log file rollover will be used, and the log file
# name will be constructed as-is, without PID and date appendage.
# This option can be used, for example, together with the logrotate tool.
#
simple-log
```

[/etc/turnserver.conf 파일](https://github.com/coturn/coturn/blob/master/docker/coturn/turnserver.conf) 참고하여 작성

### (선택) 테스트 결과

[Trickle ICE 사이트](https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice/)에서 STUN/TURN 테스트가 가능하다.

- 파이어폭스

| stun 테스트 | turn 테스트 |
| --- | --- |
| ![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/70785620/4573a6a6-7304-4e73-981d-4c446e1a2b48) <br> ![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/70785620/9018c0ed-4a3d-49e2-851c-b62109c443c4) | ![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/70785620/0450be0f-d55e-45bd-9124-2eb7d0030cbd) <br> ![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/70785620/e7bf6675-0c74-4945-9c53-f04496fe337d) |
| `{"iceServers":[{"urls":["stun:"[public_ip]:3478"],"username":"","credential":""}],"iceTransportPolicy":"all"}` | `{"iceServers":[{"urls":["turn:[public_ip]:3478"],"username":"[turn_server_user]","credential":"[turn_server_password]"}],"iceTransportPolicy":"all"}` |

- 크롬의 경우 IPv6를 지원하지 않는다는 에러가 발생함. 추후 프론트쪽 코드 변경해서 제대로 동작하는지 확인 필요

```
Note: errors from onicecandidateerror above are not neccessarily fatal. For example an IPv6 DNS lookup may fail but relay candidates can still be gathered via IPv4.
The server stun:[public_ip]:3478 returned an error with code=701:
STUN server address is incompatible.
```
  