### PR TITLE
FE/bugfix/#431-다크모드에서-채팅-글씨가-잘-안보이는-문제

### DIFF
--- a/frontend/src/components/ChatContainer/MessageBox/Message.tsx
+++ b/frontend/src/components/ChatContainer/MessageBox/Message.tsx
@@ -26,7 +26,9 @@ function Message({ type, message, profile }: MessageProps) {
             />
           </div>
         </div>
-        <div className={`chat-bubble max-w-none shadow-white ${chatStyle.bubble}`}>
+        <div
+          className={`chat-bubble max-w-none shadow-white ${chatStyle.bubble} ${type == 'right' && 'text-white-alt'}`}
+        >
           {message.length ? message : <span className="loading loading-dots loading-md"></span>}
         </div>
       </div>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -119,6 +119,7 @@ export default {
         '.text-default': { color: '#5E6E76' },
         '.text-weak': { color: '#879298' },
         '.text-white-default': { color: '#FFFFFF' },
+        '.text-white-alt': { color: '#d7dde4' },
         '.kakao-icon': { color: '#FEE500' },
         '.display-bold24': themeBase.bold_L,
         '.display-bold16': themeBase.bold_M,


### PR DESCRIPTION
### 변경 사항
- 다크모드에서 채팅 글씨가 잘 안 보이는 문제 해결

### 고민과 해결 과정

- 메세지 컴포넌트에 텍스트 색깔을 직접 지정해줬다. (기존에는 daisy 테마대로 적용됐었음)

### (선택) 테스트 결과
![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/f20a4f45-ccca-41cf-9f1a-4c030a68dcdb)
