### PR TITLE
Be/refactor/#469 단위 테스트

### DIFF
--- a/backend/was/package.json
+++ b/backend/was/package.json
@@ -13,7 +13,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest",
+    "test": "jest --runInBand",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",

--- a/backend/was/package.json
+++ b/backend/was/package.json
@@ -13,7 +13,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest --runInBand",
+    "test": "jest --runInBand --verbose",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",

--- a/backend/was/src/chat/chat.service.spec.ts
+++ b/backend/was/src/chat/chat.service.spec.ts
@@ -54,6 +54,10 @@ describe('ChatService', () => {
     );
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should be defined', () => {
     expect(service).toBeDefined();
   });

--- a/backend/was/src/chat/chat.service.spec.ts
+++ b/backend/was/src/chat/chat.service.spec.ts
@@ -1,54 +1,25 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Message } from 'src/events/type';
-import { Member } from 'src/members/entities/member.entity';
+import { Member } from 'src/members/entities';
+import {
+  message,
+  messageMock,
+  roomId,
+  roomMock,
+  wrongRoomId,
+} from 'src/mocks/chat';
+import { diffMemberId, memberId, memberMock } from 'src/mocks/members';
 import { Repository } from 'typeorm';
-import { v4 as uuidv4 } from 'uuid';
 import { ChatService } from './chat.service';
-import { CreateChattingMessageDto } from './dto/create-chatting-message.dto';
-import { UpdateChattingRoomDto } from './dto/update-chatting-room.dto';
-import { ChattingMessage } from './entities/chatting-message.entity';
-import { ChattingRoom } from './entities/chatting-room.entity';
+import { CreateChattingMessageDto, UpdateChattingRoomDto } from './dto';
+import { ChattingMessage, ChattingRoom } from './entities';
 
 describe('ChatService', () => {
   let service: ChatService;
   let chattingRoomRepository: Repository<ChattingRoom>;
   let chattingMessageRepository: Repository<ChattingMessage>;
   let membersRepository: Repository<Member>;
-
-  /**
-   * mock data
-   */
-  const memberId: string = uuidv4();
-  const roomId: string = uuidv4();
-  const messageId: string = uuidv4();
-
-  const nonMemberId: string = uuidv4();
-  const diffMemberId: string = uuidv4();
-  const nonRoomId: string = uuidv4();
-
-  const memberMock: Member = new Member();
-  memberMock.id = memberId;
-
-  const roomMock: ChattingRoom = new ChattingRoom();
-  roomMock.id = roomId;
-  roomMock.title = 'chatting room title';
-  roomMock.participant = memberMock;
-
-  const message: Message = {
-    roomId: messageId,
-    chat: {
-      role: 'user',
-      content: 'chatting message content',
-    },
-  };
-
-  const messageMock: ChattingMessage = new ChattingMessage();
-  messageMock.id = messageId;
-  messageMock.isHost = message.chat.role === 'assistant';
-  messageMock.message = message.chat.content;
-  messageMock.room = roomMock;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -110,11 +81,11 @@ describe('ChatService', () => {
     //     .spyOn(membersRepository, 'findOneBy')
     //     .mockResolvedValueOnce(null);
 
-    //   await expect(service.createRoom(nonMemberId)).rejects.toThrow(
+    //   await expect(service.createRoom(wrongMemberId)).rejects.toThrow(
     //     NotFoundException,
     //   );
 
-    //   expect(findOneByMock).toHaveBeenCalledWith({ id: nonMemberId });
+    //   expect(findOneByMock).toHaveBeenCalledWith({ id: wrongMemberId });
     // });
   });
 
@@ -146,11 +117,11 @@ describe('ChatService', () => {
         .spyOn(chattingRoomRepository, 'findOneBy')
         .mockResolvedValueOnce(null);
 
-      await expect(service.createMessage(nonRoomId, [])).rejects.toThrow(
+      await expect(service.createMessage(wrongRoomId, [])).rejects.toThrow(
         NotFoundException,
       );
 
-      expect(findOneByMock).toHaveBeenCalledWith({ id: nonRoomId });
+      expect(findOneByMock).toHaveBeenCalledWith({ id: wrongRoomId });
     });
   });
 

--- a/backend/was/src/chat/chat.service.spec.ts
+++ b/backend/was/src/chat/chat.service.spec.ts
@@ -64,9 +64,6 @@ describe('ChatService', () => {
 
   describe('createRoom', () => {
     it('채팅방을 생성한다', async () => {
-      // const findOneByMock = jest
-      //   .spyOn(membersRepository, 'findOneBy')
-      //   .mockResolvedValueOnce(memberMock);
       const saveMemberMock = jest
         .spyOn(membersRepository, 'save')
         .mockResolvedValueOnce(memberMock);
@@ -75,23 +72,16 @@ describe('ChatService', () => {
         .spyOn(chattingRoomRepository, 'save')
         .mockResolvedValueOnce(roomMock);
 
-      // expect(findOneByMock).toHaveBeenCalledWith({ id: memberId });
       await expect(service.createRoom(memberId)).resolves.not.toThrow();
       expect(saveMemberMock).toHaveBeenCalled();
       expect(saveMock).toHaveBeenCalledWith({ participant: memberMock });
     });
 
-    // it('should throw NotFoundException when member is not found', async () => {
-    //   const findOneByMock = jest
-    //     .spyOn(membersRepository, 'findOneBy')
-    //     .mockResolvedValueOnce(null);
-
-    //   await expect(service.createRoom(wrongMemberId)).rejects.toThrow(
-    //     NotFoundException,
-    //   );
-
-    //   expect(findOneByMock).toHaveBeenCalledWith({ id: wrongMemberId });
-    // });
+    /**
+     * TODO : 추후 위의 내용 삭제하고 아래 내용 작성
+     */
+    // it('채팅방을 생성한다 (로그인 하지 않은 사용자)', async () => {});
+    // it('채팅방을 생성한다 (로그인한 사용자)', async () => {});
   });
 
   describe('createMessage', () => {
@@ -105,7 +95,7 @@ describe('ChatService', () => {
         .mockResolvedValueOnce(messageMock);
 
       await expect(
-        service.createMessage(roomId, [createMessageDtoMock]),
+        service.createMessages(roomId, [createMessageDtoMock]),
       ).resolves.not.toThrow();
       expect(findOneByMock).toHaveBeenCalledWith({ id: roomId });
       expect(saveMock).toHaveBeenCalledWith({
@@ -120,7 +110,7 @@ describe('ChatService', () => {
         .spyOn(chattingRoomRepository, 'findOneBy')
         .mockResolvedValueOnce(null);
 
-      await expect(service.createMessage(wrongRoomId, [])).rejects.toThrow(
+      await expect(service.createMessages(wrongRoomId, [])).rejects.toThrow(
         NotFoundException,
       );
       expect(findOneByMock).toHaveBeenCalledWith({ id: wrongRoomId });

--- a/backend/was/src/members/members.servcie.spec.ts
+++ b/backend/was/src/members/members.servcie.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  createMemberDtoMock,
+  diffProviderId,
+  email,
+  memberId,
+  memberMock,
+  providerId,
+  updateMemberDtoMock,
+} from 'src/mocks/members';
+import { Repository } from 'typeorm';
+import { Member } from './entities';
+import { MembersService } from './members.service';
+
+describe('MembersService', () => {
+  let service: MembersService;
+  let repository: Repository<Member>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MembersService,
+        {
+          provide: getRepositoryToken(Member),
+          useClass: Repository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<MembersService>(MembersService);
+    repository = module.get<Repository<Member>>(getRepositoryToken(Member));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('회원을 생성한다', async () => {
+      const saveMock = jest
+        .spyOn(repository, 'save')
+        .mockResolvedValueOnce(memberMock);
+
+      await expect(service.create(createMemberDtoMock)).resolves.not.toThrow();
+      expect(saveMock).toHaveBeenCalledWith(
+        expect.objectContaining(createMemberDtoMock),
+      );
+    });
+  });
+
+  describe('findByEmail', () => {
+    it('해당 이메일과 제공자 ID를 가진 회원을 조회한다 (존재하는 경우)', async () => {
+      const findOneBy = jest
+        .spyOn(repository, 'findOneBy')
+        .mockResolvedValueOnce(memberMock);
+
+      const expectation: Member | null = await service.findByEmail(
+        email,
+        providerId,
+      );
+      expect(expectation).toEqual(memberMock);
+      expect(findOneBy).toHaveBeenCalledWith({
+        email: email,
+        providerId: providerId,
+      });
+    });
+
+    it('해당 이메일과 제공자 ID를 가진 회원을조회한다 (존재하지 않는 경우)', async () => {
+      const findOneBy = jest
+        .spyOn(repository, 'findOneBy')
+        .mockResolvedValueOnce(null);
+
+      const expectation: Member | null = await service.findByEmail(
+        email,
+        diffProviderId,
+      );
+      expect(expectation).toBe(null);
+      expect(findOneBy).toHaveBeenCalledWith({
+        email: email,
+        providerId: diffProviderId,
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('해당 PK의 회원 정보를 수정한다.', async () => {
+      const updateMock = jest
+        .spyOn(repository, 'update')
+        .mockResolvedValueOnce({ affected: 1 } as any);
+
+      const expectation: boolean = await service.update(
+        memberId,
+        updateMemberDtoMock,
+      );
+      expect(expectation).toBe(true);
+      expect(updateMock).toHaveBeenCalledWith(
+        { id: memberId },
+        updateMemberDtoMock,
+      );
+    });
+  });
+});

--- a/backend/was/src/members/members.service.ts
+++ b/backend/was/src/members/members.service.ts
@@ -21,15 +21,19 @@ export class MembersService {
   }
 
   async findByEmail(email: string, providerId: number): Promise<Member | null> {
-    return await this.membersRepository.findOneBy({
-      email: email,
-      providerId: providerId,
-    });
+    try {
+      return await this.membersRepository.findOneBy({
+        email: email,
+        providerId: providerId,
+      });
+    } catch (err: unknown) {
+      throw err;
+    }
   }
 
   async update(id: string, updateMemberDto: UpdateMemberDto): Promise<boolean> {
     try {
-      await this.membersRepository.update({ id }, updateMemberDto);
+      await this.membersRepository.update({ id: id }, updateMemberDto);
       return true;
     } catch (err: unknown) {
       throw err;

--- a/backend/was/src/mocks/chat/chatting-message.mocks.ts
+++ b/backend/was/src/mocks/chat/chatting-message.mocks.ts
@@ -1,6 +1,5 @@
 import { ChattingMessage, ChattingRoom } from 'src/chat/entities';
 import { Message } from 'src/events/type';
-import { v4 as uuidv4 } from 'uuid';
 import { roomMock } from './chatting-room.mocks';
 
 function makeMessageMock(
@@ -16,7 +15,7 @@ function makeMessageMock(
   return messageMock;
 }
 
-const messageId: string = uuidv4();
+const messageId: string = 'messageId';
 
 export const message: Message = {
   roomId: roomMock.id,

--- a/backend/was/src/mocks/chat/chatting-message.mocks.ts
+++ b/backend/was/src/mocks/chat/chatting-message.mocks.ts
@@ -1,0 +1,29 @@
+import { ChattingMessage, ChattingRoom } from 'src/chat/entities';
+import { Message } from 'src/events/type';
+import { v4 as uuidv4 } from 'uuid';
+import { roomMock } from './chatting-room.mocks';
+
+function makeMessageMock(
+  messageId: string,
+  message: Message,
+  roomMock: ChattingRoom,
+): ChattingMessage {
+  const messageMock: ChattingMessage = new ChattingMessage();
+  messageMock.id = messageId;
+  messageMock.isHost = message.chat.role === 'assistant';
+  messageMock.message = message.chat.content;
+  messageMock.room = roomMock;
+  return messageMock;
+}
+
+const messageId: string = uuidv4();
+
+export const message: Message = {
+  roomId: roomMock.id,
+  chat: {
+    role: 'user',
+    content: 'chatting message content',
+  },
+};
+
+export const messageMock = makeMessageMock(messageId, message, roomMock);

--- a/backend/was/src/mocks/chat/chatting-message.mocks.ts
+++ b/backend/was/src/mocks/chat/chatting-message.mocks.ts
@@ -1,28 +1,35 @@
+import { CreateChattingMessageDto } from 'src/chat/dto';
 import { ChattingMessage, ChattingRoom } from 'src/chat/entities';
-import { Message } from 'src/events/type';
+import { ChatLog } from 'src/common/types/chatbot';
 import { roomMock } from './chatting-room.mocks';
 
 function makeMessageMock(
   messageId: string,
-  message: Message,
+  chatLog: ChatLog,
   roomMock: ChattingRoom,
 ): ChattingMessage {
   const messageMock: ChattingMessage = new ChattingMessage();
   messageMock.id = messageId;
-  messageMock.isHost = message.chat.role === 'assistant';
-  messageMock.message = message.chat.content;
+  messageMock.isHost = chatLog.isHost;
+  messageMock.message = chatLog.message;
   messageMock.room = roomMock;
   return messageMock;
 }
 
 const messageId: string = 'messageId';
 
-export const message: Message = {
-  roomId: roomMock.id,
-  chat: {
-    role: 'user',
-    content: 'chatting message content',
-  },
+const chatLog: ChatLog = {
+  isHost: false,
+  message: 'message',
 };
 
-export const messageMock = makeMessageMock(messageId, message, roomMock);
+export const messageMock: ChattingMessage = makeMessageMock(
+  messageId,
+  chatLog,
+  roomMock,
+);
+
+export const messageMocks: ChattingMessage[] = [messageMock];
+
+export const createMessageDtoMock: CreateChattingMessageDto =
+  CreateChattingMessageDto.fromChatLog(roomMock.id, chatLog);

--- a/backend/was/src/mocks/chat/chatting-room.mocks.ts
+++ b/backend/was/src/mocks/chat/chatting-room.mocks.ts
@@ -1,0 +1,18 @@
+import { ChattingRoom } from 'src/chat/entities';
+import { Member } from 'src/members/entities';
+import { v4 as uuidv4 } from 'uuid';
+import { memberMock } from '../members';
+
+function makeRoomMock(roomId: string, memberMock: Member): ChattingRoom {
+  const roomMock: ChattingRoom = new ChattingRoom();
+  roomMock.id = roomId;
+  roomMock.title = 'chatting room title';
+  roomMock.participant = memberMock;
+  return roomMock;
+}
+
+export const roomId: string = uuidv4();
+
+export const wrongRoomId: string = uuidv4();
+
+export const roomMock = makeRoomMock(roomId, memberMock);

--- a/backend/was/src/mocks/chat/chatting-room.mocks.ts
+++ b/backend/was/src/mocks/chat/chatting-room.mocks.ts
@@ -1,3 +1,4 @@
+import { UpdateChattingRoomDto } from 'src/chat/dto';
 import { ChattingRoom } from 'src/chat/entities';
 import { Member } from 'src/members/entities';
 import { memberMock } from '../members';
@@ -10,8 +11,19 @@ function makeRoomMock(roomId: string, memberMock: Member): ChattingRoom {
   return roomMock;
 }
 
+function makeUpdateRoomDtoMock(title: string): UpdateChattingRoomDto {
+  const updateRoomDto: UpdateChattingRoomDto = new UpdateChattingRoomDto();
+  updateRoomDto.title = title;
+  return updateRoomDto;
+}
+
 export const roomId: string = 'roomId';
 
 export const wrongRoomId: string = 'wrongRoomId';
 
-export const roomMock = makeRoomMock(roomId, memberMock);
+export const roomMock: ChattingRoom = makeRoomMock(roomId, memberMock);
+
+export const roomMocks: ChattingRoom[] = [roomMock];
+
+export const updateRoomDtoMock: UpdateChattingRoomDto =
+  makeUpdateRoomDtoMock('revised title');

--- a/backend/was/src/mocks/chat/chatting-room.mocks.ts
+++ b/backend/was/src/mocks/chat/chatting-room.mocks.ts
@@ -1,6 +1,5 @@
 import { ChattingRoom } from 'src/chat/entities';
 import { Member } from 'src/members/entities';
-import { v4 as uuidv4 } from 'uuid';
 import { memberMock } from '../members';
 
 function makeRoomMock(roomId: string, memberMock: Member): ChattingRoom {
@@ -11,8 +10,8 @@ function makeRoomMock(roomId: string, memberMock: Member): ChattingRoom {
   return roomMock;
 }
 
-export const roomId: string = uuidv4();
+export const roomId: string = 'roomId';
 
-export const wrongRoomId: string = uuidv4();
+export const wrongRoomId: string = 'wrongRoomId';
 
 export const roomMock = makeRoomMock(roomId, memberMock);

--- a/backend/was/src/mocks/chat/index.ts
+++ b/backend/was/src/mocks/chat/index.ts
@@ -1,0 +1,2 @@
+export * from './chatting-message.mocks';
+export * from './chatting-room.mocks';

--- a/backend/was/src/mocks/members/index.ts
+++ b/backend/was/src/mocks/members/index.ts
@@ -1,0 +1,1 @@
+export * from './member.mocks';

--- a/backend/was/src/mocks/members/member.mocks.ts
+++ b/backend/was/src/mocks/members/member.mocks.ts
@@ -1,13 +1,60 @@
+import { CreateMemberDto, UpdateMemberDto } from 'src/members/dto';
 import { Member } from 'src/members/entities';
 
-function makeMemberMock(memberId: string): Member {
+function makeMemberMock(
+  memberId: string,
+  email: string,
+  nickname: string,
+  profileUrl: string,
+  providerId: number,
+): Member {
   const memberMock: Member = new Member();
   memberMock.id = memberId;
+  memberMock.email = email;
+  memberMock.nickname = nickname;
+  memberMock.profileUrl = profileUrl;
+  memberMock.providerId = providerId;
   return memberMock;
 }
+
+const nickname: string = 'nickname';
+
+const diffNickname: string = 'diffNickname';
+
+const profileUrl: string = 'profileUrl';
+
+export const email: string = 'email';
+
+export const providerId: number = 0;
+
+export const diffProviderId: number = 1;
 
 export const memberId: string = 'memberId';
 
 export const diffMemberId: string = 'diffMemberId';
 
-export const memberMock: Member = makeMemberMock(memberId);
+export const memberMock: Member = makeMemberMock(
+  memberId,
+  email,
+  nickname,
+  profileUrl,
+  providerId,
+);
+
+export const createMemberDtoMock: CreateMemberDto = CreateMemberDto.fromProfile(
+  providerId,
+  {
+    email: email,
+    nickname: nickname,
+    profileUrl: profileUrl,
+  },
+);
+
+export const updateMemberDtoMock: UpdateMemberDto = UpdateMemberDto.fromProfile(
+  providerId,
+  {
+    email: email,
+    nickname: diffNickname,
+    profileUrl: profileUrl,
+  },
+);

--- a/backend/was/src/mocks/members/member.mocks.ts
+++ b/backend/was/src/mocks/members/member.mocks.ts
@@ -1,5 +1,4 @@
 import { Member } from 'src/members/entities';
-import { v4 as uuidv4 } from 'uuid';
 
 function makeMemberMock(memberId: string): Member {
   const memberMock: Member = new Member();
@@ -7,8 +6,8 @@ function makeMemberMock(memberId: string): Member {
   return memberMock;
 }
 
-export const memberId: string = uuidv4();
+export const memberId: string = 'memberId';
 
-export const diffMemberId: string = uuidv4();
+export const diffMemberId: string = 'diffMemberId';
 
 export const memberMock = makeMemberMock(memberId);

--- a/backend/was/src/mocks/members/member.mocks.ts
+++ b/backend/was/src/mocks/members/member.mocks.ts
@@ -1,0 +1,14 @@
+import { Member } from 'src/members/entities';
+import { v4 as uuidv4 } from 'uuid';
+
+function makeMemberMock(memberId: string): Member {
+  const memberMock: Member = new Member();
+  memberMock.id = memberId;
+  return memberMock;
+}
+
+export const memberId: string = uuidv4();
+
+export const diffMemberId: string = uuidv4();
+
+export const memberMock = makeMemberMock(memberId);

--- a/backend/was/src/mocks/members/member.mocks.ts
+++ b/backend/was/src/mocks/members/member.mocks.ts
@@ -10,4 +10,4 @@ export const memberId: string = 'memberId';
 
 export const diffMemberId: string = 'diffMemberId';
 
-export const memberMock = makeMemberMock(memberId);
+export const memberMock: Member = makeMemberMock(memberId);

--- a/backend/was/src/mocks/socket/socket.mocks.ts
+++ b/backend/was/src/mocks/socket/socket.mocks.ts
@@ -11,7 +11,7 @@ export const tarotIdxMock = 0;
 
 export const chatServiceMock = {
   createRoom: () => 'room_id',
-  createMessage: jest.fn(),
+  createMessages: jest.fn(),
 } as unknown as ChatService;
 
 export const tarotServiceMock = {

--- a/backend/was/src/mocks/tarot/index.ts
+++ b/backend/was/src/mocks/tarot/index.ts
@@ -1,0 +1,2 @@
+export * from './tarot-card.mocks';
+export * from './tarot-result.mocks';

--- a/backend/was/src/mocks/tarot/tarot-card.mocks.ts
+++ b/backend/was/src/mocks/tarot/tarot-card.mocks.ts
@@ -1,0 +1,10 @@
+import { TarotCard } from 'src/tarot/entities';
+
+function makeTarotCardMock(): TarotCard {
+  const tarotCard: TarotCard = new TarotCard();
+  tarotCard.cardNo = 0;
+  tarotCard.ext = '.jpg';
+  return tarotCard;
+}
+
+export const tarotCardMock = makeTarotCardMock();

--- a/backend/was/src/mocks/tarot/tarot-card.mocks.ts
+++ b/backend/was/src/mocks/tarot/tarot-card.mocks.ts
@@ -7,4 +7,4 @@ function makeTarotCardMock(): TarotCard {
   return tarotCard;
 }
 
-export const tarotCardMock = makeTarotCardMock();
+export const tarotCardMock: TarotCard = makeTarotCardMock();

--- a/backend/was/src/mocks/tarot/tarot-result.mocks.ts
+++ b/backend/was/src/mocks/tarot/tarot-result.mocks.ts
@@ -1,15 +1,15 @@
 import { TarotResult } from 'src/tarot/entities';
-import { v4 as uuidv4 } from 'uuid';
 
 function makeTarotResultMock(id: string, message: string): TarotResult {
   const tarotResult: TarotResult = new TarotResult();
-  tarotResult.id = tarotResultId;
-  tarotResult.message = tarotResultMessage;
+  tarotResult.id = id;
+  tarotResult.message = message;
   return tarotResult;
 }
 
-export const tarotResultId = uuidv4();
-export const tarotResultMessage = 'tarot result message';
+export const tarotResultId = 'tarotResultId';
+
+export const tarotResultMessage = 'tarotResultMessage';
 
 export const tarotResultMock: TarotResult = makeTarotResultMock(
   tarotResultId,

--- a/backend/was/src/mocks/tarot/tarot-result.mocks.ts
+++ b/backend/was/src/mocks/tarot/tarot-result.mocks.ts
@@ -7,9 +7,9 @@ function makeTarotResultMock(id: string, message: string): TarotResult {
   return tarotResult;
 }
 
-export const tarotResultId = 'tarotResultId';
+export const tarotResultId: string = 'tarotResultId';
 
-export const tarotResultMessage = 'tarotResultMessage';
+export const tarotResultMessage: string = 'tarotResultMessage';
 
 export const tarotResultMock: TarotResult = makeTarotResultMock(
   tarotResultId,

--- a/backend/was/src/mocks/tarot/tarot-result.mocks.ts
+++ b/backend/was/src/mocks/tarot/tarot-result.mocks.ts
@@ -1,0 +1,17 @@
+import { TarotResult } from 'src/tarot/entities';
+import { v4 as uuidv4 } from 'uuid';
+
+function makeTarotResultMock(id: string, message: string): TarotResult {
+  const tarotResult: TarotResult = new TarotResult();
+  tarotResult.id = tarotResultId;
+  tarotResult.message = tarotResultMessage;
+  return tarotResult;
+}
+
+export const tarotResultId = uuidv4();
+export const tarotResultMessage = 'tarot result message';
+
+export const tarotResultMock: TarotResult = makeTarotResultMock(
+  tarotResultId,
+  tarotResultMessage,
+);

--- a/backend/was/src/socket/socket.service.spec.ts
+++ b/backend/was/src/socket/socket.service.spec.ts
@@ -168,7 +168,7 @@ describe('SocketService', () => {
 
     it('chatLog DB에 저장', async () => {
       await socketService.handleTarotReadEvent(clientMock, tarotIdxMock);
-      expect(chatServiceMock.createMessage).toHaveBeenCalled();
+      expect(chatServiceMock.createMessages).toHaveBeenCalled();
     });
 
     it('오류 발생 시 client에게 알림', () => {});

--- a/backend/was/src/socket/socket.service.ts
+++ b/backend/was/src/socket/socket.service.ts
@@ -140,7 +140,7 @@ export class SocketService {
       const chattingMessages = chatLogs.map((chatLog) =>
         CreateChattingMessageDto.fromChatLog(roomId, chatLog),
       );
-      return await this.chatService.createMessage(roomId, chattingMessages);
+      return await this.chatService.createMessages(roomId, chattingMessages);
     } catch (err) {
       if (err instanceof Error) {
         this.logger.error(

--- a/backend/was/src/socket/socket.service.ts
+++ b/backend/was/src/socket/socket.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { WsException } from '@nestjs/websockets';
 import { ChatService } from 'src/chat/chat.service';
-import { CreateChattingMessageDto } from 'src/chat/dto/create-chatting-message.dto';
+import { CreateChattingMessageDto } from 'src/chat/dto';
 import { ChatbotService } from 'src/chatbot/chatbot.interface';
 import { ERR_MSG } from 'src/common/constants/errors';
 import {
@@ -12,7 +12,7 @@ import { ChatLog } from 'src/common/types/chatbot';
 import type { Socket } from 'src/common/types/socket';
 import { readStream, string2Uint8ArrayStream } from 'src/common/utils/stream';
 import { LoggerService } from 'src/logger/logger.service';
-import { CreateTarotResultDto } from 'src/tarot/dto/create-tarot-result.dto';
+import { CreateTarotResultDto } from 'src/tarot/dto';
 import { TarotService } from 'src/tarot/tarot.service';
 
 @Injectable()

--- a/backend/was/src/tarot/tarot.controller.ts
+++ b/backend/was/src/tarot/tarot.controller.ts
@@ -25,9 +25,9 @@ export class TarotController {
     TarotCardDto,
   )
   async findTarotCardById(
-    @Param('id', ParseIntPipe) id: number,
+    @Param('cardNo', ParseIntPipe) cardNo: number,
   ): Promise<TarotCardDto> {
-    return await this.tarotService.findTarotCardById(id);
+    return await this.tarotService.findTarotCardByCardNo(cardNo);
   }
 
   @Get('result/:id')

--- a/backend/was/src/tarot/tarot.service.spec.ts
+++ b/backend/was/src/tarot/tarot.service.spec.ts
@@ -8,7 +8,6 @@ import {
   tarotResultMock,
 } from 'src/mocks/tarot';
 import { Repository } from 'typeorm';
-import { v4 as uuidv4 } from 'uuid';
 import { CreateTarotResultDto, TarotCardDto, TarotResultDto } from './dto';
 import { TarotCard, TarotResult } from './entities';
 import { TarotService } from './tarot.service';
@@ -47,7 +46,7 @@ describe('TarotService', () => {
   });
 
   describe('createTarotResult', () => {
-    it('should create a tarot result', async () => {
+    it('타로 결과를 생성한다', async () => {
       const createTarotResultDto: CreateTarotResultDto =
         CreateTarotResultDto.fromResult(
           tarotCardMock.cardNo,
@@ -58,10 +57,9 @@ describe('TarotService', () => {
         .spyOn(tarotResultRepository, 'save')
         .mockResolvedValueOnce(new TarotResult());
 
-      await expect(
+      expect(
         service.createTarotResult(createTarotResultDto),
       ).resolves.not.toThrow();
-
       expect(saveMock).toHaveBeenCalledWith({
         cardUrl: createTarotResultDto.cardUrl,
         message: createTarotResultDto.message,
@@ -70,67 +68,62 @@ describe('TarotService', () => {
   });
 
   describe('findTarotCardById', () => {
-    it('should find specific tarot card', async () => {
+    it('해당 번호의 타로 카드를 조회한다', async () => {
       const tarotCardDto: TarotCardDto = TarotCardDto.fromEntity(tarotCardMock);
 
       const findOneByMock = jest
         .spyOn(tarotCardRepository, 'findOneBy')
         .mockResolvedValueOnce(tarotCardMock);
 
-      const result = await service.findTarotCardById(tarotCardMock.cardNo);
-
-      expect(result).toEqual(tarotCardDto);
-
+      const expectation: TarotCardDto = await service.findTarotCardById(
+        tarotCardMock.cardNo,
+      );
+      expect(expectation).toEqual(tarotCardDto);
       expect(findOneByMock).toHaveBeenCalledWith({
         cardNo: tarotCardMock.cardNo,
         cardPack: tarotCardMock.cardPack,
       });
     });
 
-    it('should throw NotFoundException if tarot card is not found', async () => {
+    it('해당 번호의 타로 카드가 존재하지 않아 NotFoundException을 반환한다', async () => {
       const findOneByMock = jest
         .spyOn(tarotCardRepository, 'findOneBy')
         .mockResolvedValueOnce(null);
 
-      const nonTarotCardNo = 80;
-
-      await expect(service.findTarotCardById(nonTarotCardNo)).rejects.toThrow(
+      const wrongTarotCardNo = 80;
+      await expect(service.findTarotCardById(wrongTarotCardNo)).rejects.toThrow(
         NotFoundException,
       );
-
       expect(findOneByMock).toHaveBeenCalledWith({
-        cardNo: nonTarotCardNo,
+        cardNo: wrongTarotCardNo,
         cardPack: undefined,
       });
     });
   });
 
   describe('findTarotResultById', () => {
-    it('should find specific tarot result', async () => {
+    it('해당 PK의 타로 결과를 조회한다', async () => {
       const tarotResultDto = TarotResultDto.fromEntity(tarotResultMock);
 
       const findOneByMock = jest
         .spyOn(tarotResultRepository, 'findOneBy')
         .mockResolvedValueOnce(tarotResultMock);
 
-      const result = await service.findTarotResultById(tarotResultId);
-
-      expect(result).toEqual(tarotResultDto);
-
+      const expectation: TarotResultDto =
+        await service.findTarotResultById(tarotResultId);
+      expect(expectation).toEqual(tarotResultDto);
       expect(findOneByMock).toHaveBeenCalledWith({ id: tarotResultId });
     });
 
-    it('should throw NotFoundException if tarot result is not found', async () => {
+    it('해당 PK의 타로 결과가 존재하지 않아 NotFoundExceptio을 반환한다', async () => {
       const findOneByMock = jest
         .spyOn(tarotResultRepository, 'findOneBy')
         .mockResolvedValueOnce(null);
 
-      const wrongResultId = uuidv4();
-
+      const wrongResultId = 'wrongResultId';
       await expect(service.findTarotResultById(wrongResultId)).rejects.toThrow(
         NotFoundException,
       );
-
       expect(findOneByMock).toHaveBeenCalledWith({ id: wrongResultId });
     });
   });

--- a/backend/was/src/tarot/tarot.service.spec.ts
+++ b/backend/was/src/tarot/tarot.service.spec.ts
@@ -1,38 +1,22 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  tarotCardMock,
+  tarotResultId,
+  tarotResultMessage,
+  tarotResultMock,
+} from 'src/mocks/tarot';
 import { Repository } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
-import { CreateTarotResultDto } from './dto/create-tarot-result.dto';
-import { TarotCardResponseDto } from './dto/tarot-card-response.dto';
-import { TarotResultResponseDto } from './dto/tarot-result-response.dto';
-import { TarotCard } from './entities/tarot-card.entity';
-import { TarotResult } from './entities/tarot-result.entity';
+import { CreateTarotResultDto, TarotCardDto, TarotResultDto } from './dto';
+import { TarotCard, TarotResult } from './entities';
 import { TarotService } from './tarot.service';
 
 describe('TarotService', () => {
   let service: TarotService;
   let tarotCardRepository: Repository<TarotCard>;
   let tarotResultRepository: Repository<TarotResult>;
-
-  /**
-   * mock data
-   */
-  const tarotResultId = uuidv4();
-
-  const cardUrlMock =
-    'https://kr.object.ncloudstorage.com/magicconch/basic/0.jpg';
-
-  const tarotResultMessageMock = 'tarot result message';
-
-  const tarotCardMock = new TarotCard();
-  tarotCardMock.cardNo = 0;
-  tarotCardMock.ext = '.jpg';
-
-  const tarotResultMock = new TarotResult();
-  tarotResultMock.id = tarotResultId;
-  tarotResultMock.cardUrl = cardUrlMock;
-  tarotResultMock.message = tarotResultMessageMock;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -67,7 +51,7 @@ describe('TarotService', () => {
       const createTarotResultDto: CreateTarotResultDto =
         CreateTarotResultDto.fromResult(
           tarotCardMock.cardNo,
-          tarotResultMessageMock,
+          tarotResultMessage,
         );
 
       const saveMock = jest
@@ -87,8 +71,7 @@ describe('TarotService', () => {
 
   describe('findTarotCardById', () => {
     it('should find specific tarot card', async () => {
-      const tarotCardResponseDto: TarotCardResponseDto =
-        TarotCardResponseDto.fromEntity(tarotCardMock);
+      const tarotCardDto: TarotCardDto = TarotCardDto.fromEntity(tarotCardMock);
 
       const findOneByMock = jest
         .spyOn(tarotCardRepository, 'findOneBy')
@@ -96,7 +79,7 @@ describe('TarotService', () => {
 
       const result = await service.findTarotCardById(tarotCardMock.cardNo);
 
-      expect(result).toEqual(tarotCardResponseDto);
+      expect(result).toEqual(tarotCardDto);
 
       expect(findOneByMock).toHaveBeenCalledWith({
         cardNo: tarotCardMock.cardNo,
@@ -124,8 +107,7 @@ describe('TarotService', () => {
 
   describe('findTarotResultById', () => {
     it('should find specific tarot result', async () => {
-      const tarotResultResponseDto =
-        TarotResultResponseDto.fromEntity(tarotResultMock);
+      const tarotResultDto = TarotResultDto.fromEntity(tarotResultMock);
 
       const findOneByMock = jest
         .spyOn(tarotResultRepository, 'findOneBy')
@@ -133,7 +115,7 @@ describe('TarotService', () => {
 
       const result = await service.findTarotResultById(tarotResultId);
 
-      expect(result).toEqual(tarotResultResponseDto);
+      expect(result).toEqual(tarotResultDto);
 
       expect(findOneByMock).toHaveBeenCalledWith({ id: tarotResultId });
     });
@@ -143,13 +125,13 @@ describe('TarotService', () => {
         .spyOn(tarotResultRepository, 'findOneBy')
         .mockResolvedValueOnce(null);
 
-      const nonResultId = uuidv4();
+      const wrongResultId = uuidv4();
 
-      await expect(service.findTarotResultById(nonResultId)).rejects.toThrow(
+      await expect(service.findTarotResultById(wrongResultId)).rejects.toThrow(
         NotFoundException,
       );
 
-      expect(findOneByMock).toHaveBeenCalledWith({ id: nonResultId });
+      expect(findOneByMock).toHaveBeenCalledWith({ id: wrongResultId });
     });
   });
 });

--- a/backend/was/src/tarot/tarot.service.spec.ts
+++ b/backend/was/src/tarot/tarot.service.spec.ts
@@ -71,7 +71,7 @@ describe('TarotService', () => {
     });
   });
 
-  describe('findTarotCardById', () => {
+  describe('findTarotCardByCardNo', () => {
     it('해당 번호의 타로 카드를 조회한다', async () => {
       const tarotCardDto: TarotCardDto = TarotCardDto.fromEntity(tarotCardMock);
 
@@ -79,7 +79,7 @@ describe('TarotService', () => {
         .spyOn(tarotCardRepository, 'findOneBy')
         .mockResolvedValueOnce(tarotCardMock);
 
-      const expectation: TarotCardDto = await service.findTarotCardById(
+      const expectation: TarotCardDto = await service.findTarotCardByCardNo(
         tarotCardMock.cardNo,
       );
       expect(expectation).toEqual(tarotCardDto);
@@ -95,9 +95,9 @@ describe('TarotService', () => {
         .mockResolvedValueOnce(null);
 
       const wrongTarotCardNo = 80;
-      await expect(service.findTarotCardById(wrongTarotCardNo)).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        service.findTarotCardByCardNo(wrongTarotCardNo),
+      ).rejects.toThrow(NotFoundException);
       expect(findOneByMock).toHaveBeenCalledWith({
         cardNo: wrongTarotCardNo,
         cardPack: undefined,

--- a/backend/was/src/tarot/tarot.service.spec.ts
+++ b/backend/was/src/tarot/tarot.service.spec.ts
@@ -41,6 +41,10 @@ describe('TarotService', () => {
     );
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should be defined', () => {
     expect(service).toBeDefined();
   });

--- a/backend/was/src/tarot/tarot.service.spec.ts
+++ b/backend/was/src/tarot/tarot.service.spec.ts
@@ -55,7 +55,7 @@ describe('TarotService', () => {
 
       const saveMock = jest
         .spyOn(tarotResultRepository, 'save')
-        .mockResolvedValueOnce(new TarotResult());
+        .mockResolvedValueOnce(tarotResultMock);
 
       expect(
         service.createTarotResult(createTarotResultDto),
@@ -115,7 +115,7 @@ describe('TarotService', () => {
       expect(findOneByMock).toHaveBeenCalledWith({ id: tarotResultId });
     });
 
-    it('해당 PK의 타로 결과가 존재하지 않아 NotFoundExceptio을 반환한다', async () => {
+    it('해당 PK의 타로 결과가 존재하지 않아 NotFoundException을 반환한다', async () => {
       const findOneByMock = jest
         .spyOn(tarotResultRepository, 'findOneBy')
         .mockResolvedValueOnce(null);

--- a/backend/was/src/tarot/tarot.service.ts
+++ b/backend/was/src/tarot/tarot.service.ts
@@ -30,24 +30,32 @@ export class TarotService {
   /**
    * TODO : 추후 타로 카드팩이 커스텀이 가능한 경우, 전체적인 로직 수정 필요
    */
-  async findTarotCardById(id: number): Promise<TarotCardDto> {
-    const tarotCard: TarotCard | null =
-      await this.tarotCardRepository.findOneBy({
-        cardNo: id,
-        cardPack: undefined,
-      });
-    if (!tarotCard) {
-      throw new NotFoundException(ERR_MSG.TAROT_CARD_NOT_FOUND);
+  async findTarotCardByCardNo(cardNo: number): Promise<TarotCardDto> {
+    try {
+      const tarotCard: TarotCard | null =
+        await this.tarotCardRepository.findOneBy({
+          cardNo: cardNo,
+          cardPack: undefined,
+        });
+      if (!tarotCard) {
+        throw new NotFoundException(ERR_MSG.TAROT_CARD_NOT_FOUND);
+      }
+      return TarotCardDto.fromEntity(tarotCard);
+    } catch (err: unknown) {
+      throw err;
     }
-    return TarotCardDto.fromEntity(tarotCard);
   }
 
   async findTarotResultById(id: string): Promise<TarotResultDto> {
-    const tarotResult: TarotResult | null =
-      await this.tarotResultRepository.findOneBy({ id });
-    if (!tarotResult) {
-      throw new NotFoundException(ERR_MSG.TAROT_RESULT_NOT_FOUND);
+    try {
+      const tarotResult: TarotResult | null =
+        await this.tarotResultRepository.findOneBy({ id: id });
+      if (!tarotResult) {
+        throw new NotFoundException(ERR_MSG.TAROT_RESULT_NOT_FOUND);
+      }
+      return TarotResultDto.fromEntity(tarotResult);
+    } catch (err: unknown) {
+      throw err;
     }
-    return TarotResultDto.fromEntity(tarotResult);
   }
 }

--- a/backend/was/tsconfig.build.json
+++ b/backend/was/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "**/*mocks"]
 }


### PR DESCRIPTION
resolved #469 

### 변경 사항
- `tarot`, `chat` 단위 테스트 변경사항 적용
- `members` 단위 테스트 작성

### 고민과 해결 과정

추후 소켓 통신에서 로그인 정보를 받아와서 그에 따른 분기 처리가 필요하다. 일단 의사 코드를 주석으로 남겨놓고, 협의 후에 이를 반영할 예정이다.   

### (선택) 테스트 결과

서비스 수정 사항을 반영하여 다시 테스트 코드를 작성했다.
| `chatService` | `tarotService` |
| --- | --- |
| ![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/70785620/ddc915e9-8486-4c90-8909-f28a5b866f48) | ![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/70785620/3fb182e0-c7c1-4d6e-b305-d66f148c073f) |
