### PR TITLE
Be/bugfix/#485 findTarotCardByCardNo

### DIFF
--- a/backend/was/src/tarot/tarot.controller.ts
+++ b/backend/was/src/tarot/tarot.controller.ts
@@ -18,13 +18,13 @@ import { TarotService } from './tarot.service';
 export class TarotController {
   constructor(private readonly tarotService: TarotService) {}
 
-  @Get('card/:id')
+  @Get('card/:cardNo')
   @FindTarotCardDecorator(
     '타로 카드 이미지',
-    { type: 'integer', name: 'id' },
+    { type: 'integer', name: 'cardNo' },
     TarotCardDto,
   )
-  async findTarotCardById(
+  async findTarotCardByCardNo(
     @Param('cardNo', ParseIntPipe) cardNo: number,
   ): Promise<TarotCardDto> {
     return await this.tarotService.findTarotCardByCardNo(cardNo);


### PR DESCRIPTION
### 변경 사항
- 변수명, 파라미터명을 직관적으로 변경하는 과정에서 일부만 수정하여 유효성 검사 에러 발생
- :id -> :cardNo 로 변경하여 일치하도록 수정

### 고민과 해결 과정
```diff
- @Get('card/:id')
+ @Get('card/:cardNo')
@FindTarotCardDecorator(
  '타로 카드 이미지',
  { type: 'integer', name: 'cardNo' },
  TarotCardDto,
)
async findTarotCardByCardNo(
  @Param('cardNo', ParseIntPipe) cardNo: number,
): Promise<TarotCardDto> {
  return await this.tarotService.findTarotCardByCardNo(cardNo);
}
```

### (선택) 테스트 결과