### PR TITLE
Be/bugfix/#488 도커 healthcheck (액션 오류)

### DIFF
--- a/.github/workflows/blue-green-cd.yml
+++ b/.github/workflows/blue-green-cd.yml
@@ -41,7 +41,7 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: ${{ secrets.SSH_PORT }}
-          source: "backend/.env,backend/deploy.sh,backend/config,backend/compose.blue-deploy.yml,backend/compose.green-deploy.yml,backend/Dockerfile.nginx"
+          source: "backend/.env,backend/deploy.sh,backend/send-slack-message.sh,backend/config,backend/compose.blue-deploy.yml,backend/compose.green-deploy.yml,backend/Dockerfile.nginx"
           target: "~/app/"
           overwrite: true
 
@@ -72,22 +72,21 @@ jobs:
 
       - name: Run a New Version of the application on Remote Server
         uses: appleboy/ssh-action@master
+        env:
+          SLACK_WEBHOOK_URI: ${{ secrets.SLACK_WEBHOOK_URI_FOR_GITHUB_ACTIONS }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_ACTOR: ${{ github.actor }}
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: ${{ secrets.SSH_PORT }}
+          envs: SLACK_WEBHOOK_URI,GITHUB_WORKFLOW,GITHUB_REF,GITHUB_ACTOR
           script: |
             cd ~/app/backend
             chmod +x deploy.sh
-            export DEPLOYMENT_SUCCESS='success'
-            source deploy.sh || export DEPLOYMENT_SUCCESS='failure'
-
-      - uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ env.DEPLOYMENT_SUCCESS }}
-          author_name: Blue/Green CD
-          fields: message,author,action,workflow,job
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URI_FOR_GITHUB_ACTIONS }}
-        if: always()
+            DEPLOYMENT_RESULT='Success'
+            ./deploy.sh || DEPLOYMENT_RESULT='Fail'
+            chmod +x send-slack-message.sh
+            ./send-slack-message.sh $SLACK_WEBHOOK_URI $DEPLOYMENT_RESULT $GITHUB_REF $GITHUB_ACTOR $GITHUB_WORKFLOW

--- a/backend/send-slack-message.sh
+++ b/backend/send-slack-message.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+SLACK_WEBHOOK_URI=$1
+DEPLOYMENT_RESULT=$2
+GITHUB_REF=$3
+GITHUB_ACTOR=$4
+GITHUB_WORKFLOW=$5
+
+COLOR=''
+
+if [ "$DEPLOYMENT_RESULT" == 'Success' ]; then
+  COLOR="good"
+else
+  COLOR="danger"
+fi
+
+BRANCH=$(echo "$GITHUB_REF" | sed 's|^refs/heads/||')
+
+SLACK_MESSAGE="{
+  \"attachments\": [{
+    \"color\": \"$COLOR\",
+    \"mrkdwn_in\": [\"text\", \"fields\"],
+    \"pretext\": \"타로밀크티의 GitHub Actions에서 보내는 슬랙 알림입니다.\",
+    \"title\": \":rocket: Deployment Result - $DEPLOYMENT_RESULT :rocket:\",
+    \"fields\": [
+      {\"title\": \"Branch\", \"value\": \"$BRANCH\"},
+      {\"title\": \"Author\", \"value\": \"$GITHUB_ACTOR\"},
+      {\"title\": \"Workflow\", \"value\": \"$GITHUB_WORKFLOW\"}
+    ],
+    \"author_name\": \"타로밀크티 GitHub Actions\"
+  }]
+}"
+
+curl -X POST -H 'Content-type: application/json' --data "$SLACK_MESSAGE" "$SLACK_WEBHOOK_URI"


### PR DESCRIPTION
### 변경 사항
슬랙으로 배포 결과 알림 전달하는 로직 수정

### 고민과 해결 과정
`ssh-action`에서 `GITHUB_ENV`라는 환경변수에 접근하는 로직이 동작하지 않았다. 원격 서버에서 스크립트를 실행하는 로직이기 때문에 `GITHUB_ACTION`에 접근을 하지 못하는 것으로 추정된다.

기존에 사용하고 있던 `action-slack`에 배포 결과를 전달할 수 없어서 해당 액션을 삭제하고, `ssh-action`에서 슬랙 알림을 보내도록 수정했다.

### (선택) 테스트 결과