### PR TITLE
FE/feature/#502 useOverlay훅 테스트코드 작성

### DIFF
--- a/frontend/src/business/hooks/useOverlay/useOverlay.spec.tsx
+++ b/frontend/src/business/hooks/useOverlay/useOverlay.spec.tsx
@@ -1,0 +1,23 @@
+import useOverlay, { OverlayProvider } from '.';
+import { renderHook, screen, waitFor } from '@testing-library/react';
+
+describe('useOvelay훅 테스트', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => <OverlayProvider>{children}</OverlayProvider>;
+
+  it('useOverlay의 open, close함수 호출시 mount되고 unmount된다.', async () => {
+    const { result } = renderHook(() => useOverlay(), { wrapper });
+    const { open, close } = result.current;
+
+    // 오버레이가 열린다.
+    waitFor(() => {
+      open(() => <div>testOverlay</div>);
+      expect(screen.getByText('testOverlay')).toBeInTheDocument();
+    });
+
+    // 오버레이가 닫힌다.
+    waitFor(() => {
+      close();
+      expect(screen.queryByText('testOverlay')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/business/hooks/useOverlay/useOverlay.spec.tsx
+++ b/frontend/src/business/hooks/useOverlay/useOverlay.spec.tsx
@@ -1,5 +1,5 @@
 import useOverlay, { OverlayProvider } from '.';
-import { renderHook, screen, waitFor } from '@testing-library/react';
+import { act, renderHook, screen } from '@testing-library/react';
 
 describe('useOvelay훅 테스트', () => {
   const wrapper = ({ children }: { children: React.ReactNode }) => <OverlayProvider>{children}</OverlayProvider>;
@@ -9,15 +9,15 @@ describe('useOvelay훅 테스트', () => {
     const { open, close } = result.current;
 
     // 오버레이가 열린다.
-    waitFor(() => {
+    act(() => {
       open(() => <div>testOverlay</div>);
-      expect(screen.getByText('testOverlay')).toBeInTheDocument();
     });
+    expect(screen.getByText('testOverlay')).toBeInTheDocument();
 
     // 오버레이가 닫힌다.
-    waitFor(() => {
+    act(() => {
       close();
-      expect(screen.queryByText('testOverlay')).not.toBeInTheDocument();
     });
+    expect(screen.queryByText('testOverlay')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### 변경 사항
- useOverlay 로직에 대해 renderHook을 사용해 테스트코드 작성 완료

### 고민과 해결 과정
useOverlay는 오버레이를 추가하고, 닫는 훅임
그래서 이 두가지 동작이 제대로 되는지에 대해 테스트를 진행함.

방법은 두가지가 있었음 실제로 테스트 컴포넌트를 작성하고, 안에서 제대로 동작이 되는지 보는것과
react testing library가 제공하는 renderHook 메서드를 사용하는것.

굳이 테스트코드를 위한 테스트컴포넌트를 작성할정도로 복잡한 로직도 아니고
다른 훅을 의존하지 않기에 renderHook 메서드를 사용함

이 때 waitFor을 사용했는데 waitFor는 변경된 결과를 기다릴 때 사용하라고 문서에 가이드가 있었음 [링크](https://testing-library.com/docs/dom-testing-library/api-async/#waitfor)
그래서 act로 유저의 액션을 동기적으로 일으킴 [링크](https://testing-library.com/docs/preact-testing-library/api/#act) 그래서 리렌더링 되면 act 메서드 다음줄로 넘어가게 됨


### (선택) 테스트 결과
<img width="445" alt="스크린샷 2024-01-29 오후 6 57 52" src="https://github.com/boostcampwm2023/web09-MagicConch/assets/43428643/0fe313bb-94be-40c4-9713-6e16d2e5d055">

closed #502 