### PR TITLE
FE/bugfix/#432 채팅방개설 취소시 튕기는버그

### DIFF
--- a/frontend/src/@types/close.d.ts
+++ b/frontend/src/@types/close.d.ts
@@ -1,7 +1,6 @@
-interface CloseFunc {
-  close: () => void;
-}
-
 interface ClosePopupFunc {
   closePopup: () => void;
+}
+interface CloseOverlayFunc {
+  closeOverlay: () => void;
 }

--- a/frontend/src/business/hooks/useBlocker.ts
+++ b/frontend/src/business/hooks/useBlocker.ts
@@ -27,10 +27,7 @@ export function useBlocker({ when, onConfirm, onCancel }: useBlockerParams) {
             onConfirm?.();
           });
         },
-        onCancel: ({ close }) => {
-          onCancel?.();
-          close();
-        },
+        onCancel,
       });
       return true;
     }

--- a/frontend/src/business/hooks/useOverlay/types.tsx
+++ b/frontend/src/business/hooks/useOverlay/types.tsx
@@ -1,1 +1,1 @@
-export type CreateOverlayElement = (props: { opened: boolean; close: () => void }) => JSX.Element;
+export type CreateOverlayElement = (props: { opened: boolean; closeOverlay: () => void }) => JSX.Element;

--- a/frontend/src/business/hooks/useOverlay/useOverlay.spec.tsx
+++ b/frontend/src/business/hooks/useOverlay/useOverlay.spec.tsx
@@ -6,17 +6,17 @@ describe('useOvelay훅 테스트', () => {
 
   it('useOverlay의 open, close함수 호출시 mount되고 unmount된다.', async () => {
     const { result } = renderHook(() => useOverlay(), { wrapper });
-    const { open, close } = result.current;
+    const { closeOverlay, openOverlay } = result.current;
 
     // 오버레이가 열린다.
     act(() => {
-      open(() => <div>testOverlay</div>);
+      openOverlay(() => <div>testOverlay</div>);
     });
     expect(screen.getByText('testOverlay')).toBeInTheDocument();
 
     // 오버레이가 닫힌다.
     act(() => {
-      close();
+      closeOverlay();
     });
     expect(screen.queryByText('testOverlay')).not.toBeInTheDocument();
   });

--- a/frontend/src/business/hooks/useOverlay/useOverlay.tsx
+++ b/frontend/src/business/hooks/useOverlay/useOverlay.tsx
@@ -25,19 +25,19 @@ export default function useOverlay() {
 
   return useMemo(
     () => ({
-      open: (OverlayElement: CreateOverlayElement) => {
+      openOverlay: (OverlayElement: CreateOverlayElement) => {
         mount(
           id,
           <div className="fixed top-[50%] left-[50%] -translate-x-[50%] -translate-y-[50%] z-10">
             <OverlayElement
               key={String(new Date())}
               opened={opened}
-              close={() => unmount(id)}
+              closeOverlay={() => unmount(id)}
             />
           </div>,
         );
       },
-      close: () => {
+      closeOverlay: () => {
         unmount(id);
       },
     }),

--- a/frontend/src/business/hooks/usePopup/useExitPopup.tsx
+++ b/frontend/src/business/hooks/usePopup/useExitPopup.tsx
@@ -4,7 +4,7 @@ import Popup from '@components/Popup';
 
 interface openExitPopupParams {
   onConfirm: ({ close }: CloseFunc) => void;
-  onCancel?: ({ close }: CloseFunc) => void;
+  onCancel?: () => void;
 }
 
 export function useExitPopup() {
@@ -15,7 +15,7 @@ export function useExitPopup() {
       <Popup
         close={close}
         onConfirm={() => onConfirm({ close })}
-        onCancel={() => onCancel?.({ close })}
+        onCancel={onCancel}
       >
         <div className="flex-with-center flex-col gap-16">
           <div>나갈거야?</div>

--- a/frontend/src/business/hooks/usePopup/useExitPopup.tsx
+++ b/frontend/src/business/hooks/usePopup/useExitPopup.tsx
@@ -3,18 +3,18 @@ import useOverlay from '../useOverlay';
 import Popup from '@components/Popup';
 
 interface openExitPopupParams {
-  onConfirm: ({ close }: CloseFunc) => void;
+  onConfirm: ({ closeOverlay }: CloseOverlayFunc) => void;
   onCancel?: () => void;
 }
 
 export function useExitPopup() {
-  const { open } = useOverlay();
+  const { openOverlay } = useOverlay();
 
   const openExitPopup = ({ onConfirm, onCancel }: openExitPopupParams) => {
-    open(({ close }) => (
+    openOverlay(({ closeOverlay }) => (
       <Popup
-        close={close}
-        onConfirm={() => onConfirm({ close })}
+        closePopup={closeOverlay}
+        onConfirm={() => onConfirm({ closeOverlay })}
         onCancel={onCancel}
       >
         <div className="flex-with-center flex-col gap-16">

--- a/frontend/src/business/hooks/usePopup/useLoginPopup.tsx
+++ b/frontend/src/business/hooks/usePopup/useLoginPopup.tsx
@@ -7,10 +7,10 @@ interface UseLoginPopupParams {
 }
 
 export function useLoginPopup({ moveAiChat }: UseLoginPopupParams) {
-  const { open } = useOverlay();
+  const { openOverlay } = useOverlay();
 
   const openLoginPopup = () => {
-    open(() => <LoginPopup moveAiChat={moveAiChat}></LoginPopup>);
+    openOverlay(() => <LoginPopup moveAiChat={moveAiChat}></LoginPopup>);
   };
 
   return { openLoginPopup };

--- a/frontend/src/business/hooks/usePopup/usePasswordPopup.tsx
+++ b/frontend/src/business/hooks/usePopup/usePasswordPopup.tsx
@@ -18,7 +18,7 @@ export function usePasswordPopup() {
 
     open(({ close: closePopup }) => (
       <PasswordPopup
-        close={close}
+        close={closePopup}
         onCancel={onCancel}
         onSubmit={password => {
           onSubmit?.({ password, closePopup });

--- a/frontend/src/business/hooks/usePopup/usePasswordPopup.tsx
+++ b/frontend/src/business/hooks/usePopup/usePasswordPopup.tsx
@@ -6,22 +6,22 @@ import { randomString } from '@utils/ramdom';
 
 type openPasswordPopupParams = {
   host?: boolean;
-  onSubmit?: ({ password, closePopup }: { password: string; closePopup: () => void }) => void;
+  onSubmit?: ({ password, closeOverlay }: { password: string } & CloseOverlayFunc) => void;
   onCancel?: () => void;
 };
 
 export function usePasswordPopup() {
-  const { open } = useOverlay();
+  const { openOverlay } = useOverlay();
 
   const openPasswordPopup = ({ host, onSubmit, onCancel }: openPasswordPopupParams) => {
     const defaultValue = host ? randomString() : '';
 
-    open(({ close: closePopup }) => (
+    openOverlay(({ closeOverlay }) => (
       <PasswordPopup
-        close={closePopup}
+        closePopup={closeOverlay}
         onCancel={onCancel}
         onSubmit={password => {
-          onSubmit?.({ password, closePopup });
+          onSubmit?.({ password, closeOverlay });
         }}
         defaultValue={defaultValue}
       />

--- a/frontend/src/business/hooks/useTOLD.tsx
+++ b/frontend/src/business/hooks/useTOLD.tsx
@@ -4,18 +4,18 @@ type TOLD_TYPE = 'AI' | 'HUMAN';
 
 export default function useTOLD(event: TOLD_TYPE) {
   const global = window as any;
-  const { open } = useOverlay();
+  const { openOverlay } = useOverlay();
 
   const displayTold = () => {
     global.dataLayer.push({ event });
 
-    open(({ close }) => {
+    openOverlay(({ closeOverlay }) => {
       const interval = setInterval(() => {
         const container = document.querySelector('#told-container');
         if (container && !container.innerHTML) {
           return;
         }
-        close();
+        closeOverlay();
         clearInterval(interval);
       }, 1000);
 

--- a/frontend/src/business/hooks/useTarotSpread/useDisplayTarotCard.tsx
+++ b/frontend/src/business/hooks/useTarotSpread/useDisplayTarotCard.tsx
@@ -3,11 +3,11 @@ import useOverlay from '@business/hooks/useOverlay';
 import { getTarotImageQuery } from '@stores/queries/getTarotImageQuery';
 
 export default function useDisplayTarotCard() {
-  const { open } = useOverlay();
+  const { openOverlay } = useOverlay();
 
   const displayTarotCard = (tarotId: number) => {
-    open(({ close }) => {
-      setTimeout(close, 5000);
+    openOverlay(({ closeOverlay }) => {
+      setTimeout(closeOverlay, 5000);
 
       return (
         <div className="animate-shining">

--- a/frontend/src/business/hooks/useTarotSpread/useHumanTarotSpread.tsx
+++ b/frontend/src/business/hooks/useTarotSpread/useHumanTarotSpread.tsx
@@ -28,15 +28,14 @@ export function useHumanTarotSpread(onPickCard: (idx: number) => void) {
   const { openTarotSpread } = useTarotSpread(pickCard);
   const { displayTarotCard } = useDisplayTarotCard();
 
-  const { open } = useOverlay();
+  const { openOverlay } = useOverlay();
 
   const tarotButtonClick = () => {
-    open(({ close }) => (
+    openOverlay(({ closeOverlay }) => (
       <Popup
-        close={close}
-        onCancel={() => close()}
+        closePopup={closeOverlay}
         onConfirm={() => {
-          close();
+          closeOverlay();
           requestTarotSpread();
         }}
       >

--- a/frontend/src/business/hooks/useTarotSpread/useTarotSpread.tsx
+++ b/frontend/src/business/hooks/useTarotSpread/useTarotSpread.tsx
@@ -3,17 +3,17 @@ import TarotSpread from '@components/TarotSpread';
 import useOverlay from '@business/hooks/useOverlay';
 
 export function useTarotSpread(setTarotId: (idx: number) => void) {
-  const { open } = useOverlay();
+  const { openOverlay } = useOverlay();
 
   const pickCard = (idx: number) => {
     setTarotId(idx);
   };
 
   const openTarotSpread = () => {
-    open(({ opened, close }) => (
+    openOverlay(({ opened, closeOverlay }) => (
       <TarotSpread
         opened={opened}
-        close={close}
+        closeSpread={closeOverlay}
         pickCard={pickCard}
       />
     ));

--- a/frontend/src/business/hooks/useWebRTC/useDataChannel.eventListeners.ts
+++ b/frontend/src/business/hooks/useWebRTC/useDataChannel.eventListeners.ts
@@ -1,10 +1,11 @@
-import WebRTC from '@business/services/__mocks__/WebRTC';
+import { HumanSocketManager } from '@business/services/SocketManager';
+import WebRTC from '@business/services/WebRTC';
 
 import { ProfileInfo } from '@stores/zustandStores/useProfileInfo';
 
 import { array2ArrayBuffer } from '@utils/array';
 
-const webRTC = WebRTC.getInstance();
+const webRTC = WebRTC.getInstance(HumanSocketManager.getInstance());
 
 export async function setMediaStates({
   ev: { data },

--- a/frontend/src/business/hooks/useWebRTC/useSignalingSocket.spec.ts
+++ b/frontend/src/business/hooks/useWebRTC/useSignalingSocket.spec.ts
@@ -62,7 +62,7 @@ describe('useSignalingSocket 훅', () => {
     const testDatas = [{ onSuccess: vi.fn() }, { onHostExit: vi.fn() }, { onFail: vi.fn() }, { onFull: vi.fn() }];
 
     testDatas.forEach(({ onFail, onFull, onHostExit, onSuccess }) => {
-      initGuestSocketEvents({ password, roomName, closePopup: vi.fn(), onSuccess, onHostExit, onFail, onFull });
+      initGuestSocketEvents({ password, roomName, closeOverlay: vi.fn(), onSuccess, onHostExit, onFail, onFull });
 
       expect(socket.emit).toBeCalledWith('joinRoom', roomName, password);
 

--- a/frontend/src/business/hooks/useWebRTC/useSignalingSocket.ts
+++ b/frontend/src/business/hooks/useWebRTC/useSignalingSocket.ts
@@ -20,7 +20,8 @@ export function useSignalingSocket() {
     openPasswordPopup({
       host: true,
       onCancel,
-      onSubmit: ({ password, closePopup }) => initHostSocketEvents({ password, closePopup, roomName, onSuccess }),
+      onSubmit: ({ password, closeOverlay }) =>
+        initHostSocketEvents({ password, closePopup: closeOverlay, roomName, onSuccess }),
     });
   };
 
@@ -38,8 +39,8 @@ export function useSignalingSocket() {
     onHostExit?: VoidFunction;
   }) => {
     openPasswordPopup({
-      onSubmit: ({ password, closePopup }) =>
-        initGuestSocketEvents({ password, roomName, closePopup, onSuccess, onHostExit, onFail, onFull }),
+      onSubmit: ({ password, closeOverlay }) =>
+        initGuestSocketEvents({ password, roomName, closeOverlay, onSuccess, onHostExit, onFail, onFull }),
     });
   };
   const checkRoomExist = ({
@@ -91,7 +92,7 @@ export function initGuestSocketEvents({
   onFull,
   onSuccess,
   onHostExit,
-  closePopup,
+  closeOverlay,
 }: {
   password: string;
   roomName: string;
@@ -99,7 +100,7 @@ export function initGuestSocketEvents({
   onFail?: VoidFunction;
   onSuccess?: onSuccessJoinRoom;
   onHostExit?: VoidFunction;
-  closePopup: VoidFunction;
+  closeOverlay: VoidFunction;
 }) {
   const socketManager = HumanSocketManager.getInstance();
 
@@ -112,7 +113,7 @@ export function initGuestSocketEvents({
     socketManager.on('roomFull', onFull);
   }
   if (onSuccess) {
-    socketManager.on('joinRoomSuccess', () => onSuccess({ closePopup }));
+    socketManager.on('joinRoomSuccess', () => onSuccess({ closePopup: closeOverlay }));
   }
   if (onHostExit) {
     socketManager.on('hostExit', onHostExit);

--- a/frontend/src/components/Popup/PasswordPopup.tsx
+++ b/frontend/src/components/Popup/PasswordPopup.tsx
@@ -3,13 +3,13 @@ import { useRef } from 'react';
 import Popup from './Popup';
 
 interface PasswordPopupProps {
-  close: () => void;
+  closePopup: () => void;
   onCancel?: () => void;
   defaultValue?: string;
   onSubmit: (password: string) => void;
 }
 
-export default function PasswordPopup({ close, onCancel, defaultValue, onSubmit }: PasswordPopupProps) {
+export default function PasswordPopup({ closePopup, onCancel, defaultValue, onSubmit }: PasswordPopupProps) {
   const passwordInput = useRef<HTMLInputElement>(null);
 
   const passwordSubmit = () => {
@@ -26,7 +26,7 @@ export default function PasswordPopup({ close, onCancel, defaultValue, onSubmit 
 
   return (
     <Popup
-      close={close}
+      closePopup={closePopup}
       onCancel={onCancel}
       onConfirm={passwordSubmit}
     >

--- a/frontend/src/components/Popup/Popup.tsx
+++ b/frontend/src/components/Popup/Popup.tsx
@@ -7,7 +7,7 @@ interface PopupProps {
   children: React.ReactNode;
 }
 
-export default function Popup({ onCancel, onConfirm, children }: PopupProps) {
+export default function Popup({ close, onCancel, onConfirm, children }: PopupProps) {
   const closeWithCancel = () => {
     onCancel?.();
     close();

--- a/frontend/src/components/Popup/Popup.tsx
+++ b/frontend/src/components/Popup/Popup.tsx
@@ -1,16 +1,16 @@
 import { Button } from '@components/Buttons';
 
 interface PopupProps {
-  close: () => void;
+  closePopup: () => void;
   onCancel?: () => void;
   onConfirm?: () => void;
   children: React.ReactNode;
 }
 
-export default function Popup({ close, onCancel, onConfirm, children }: PopupProps) {
+export default function Popup({ closePopup, onCancel, onConfirm, children }: PopupProps) {
   const closeWithCancel = () => {
     onCancel?.();
-    close();
+    closePopup();
   };
   return (
     <div className="w-[100vw] h-[100vh] flex-with-center">

--- a/frontend/src/components/TarotSpread/TarotSpread.tsx
+++ b/frontend/src/components/TarotSpread/TarotSpread.tsx
@@ -14,7 +14,7 @@ const __iOS__ = browser?.os?.includes('iOS');
 
 interface TarotSpreadProps {
   opened: boolean;
-  close: () => void;
+  closeSpread: () => void;
   pickCard: (idx: number) => void;
 }
 
@@ -26,7 +26,7 @@ interface PageOffset {
 const spreadSound = new Audio('/spreadCards.mp3');
 const flipSound = new Audio('/flipCard.mp3');
 
-export default function TarotSpread({ opened, close, pickCard }: TarotSpreadProps) {
+export default function TarotSpread({ opened, closeSpread, pickCard }: TarotSpreadProps) {
   const [closing, setClosing] = useState<boolean>(!opened);
   const [dragging, setDragging] = useState<boolean>(false);
   const [pickedId, setPickedId] = useState<number>(0);
@@ -45,7 +45,7 @@ export default function TarotSpread({ opened, close, pickCard }: TarotSpreadProp
 
   useEffect(() => {
     setPickedId(Math.floor(Math.random() * TAROT_CARDS_LENGTH));
-    const closeWithFadeOut = ({ animationName }: AnimationEvent) => animationName == 'fadeOut' && close();
+    const closeWithFadeOut = ({ animationName }: AnimationEvent) => animationName == 'fadeOut' && closeSpread();
 
     addEventListener('animationend', closeWithFadeOut);
     setTimeout(spreadTarotCards, 10);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -31,10 +31,10 @@
       "@mocks/*": ["mocks/*"]
     },
 
+    "types": ["vite/globals"]
     
   },
   "typeRoots": ["./node_modules/@types", "./src/@types"],
   "include": ["src", "vite-env.d.ts", "@types", ".src/test/setup.ts"],
-  "references": [{ "path": "./tsconfig.node.json" }],
-  "exclude": ["**/__mocks__/**/*"]
+  "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -31,10 +31,10 @@
       "@mocks/*": ["mocks/*"]
     },
 
-    // "types": ["vitest/globals"],
     
   },
   "typeRoots": ["./node_modules/@types", "./src/@types"],
-  "include": ["src", "vite-env.d.ts", "@types", ".src/test/setup.ts", "__mocks__"],
+  "include": ["src", "vite-env.d.ts", "@types", ".src/test/setup.ts"],
   "references": [{ "path": "./tsconfig.node.json" }],
+  "exclude": ["**/__mocks__/**/*"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -30,9 +30,6 @@
       "@utils/*": ["utils/*"],
       "@mocks/*": ["mocks/*"]
     },
-
-    "types": ["vite/globals"]
-    
   },
   "typeRoots": ["./node_modules/@types", "./src/@types"],
   "include": ["src", "vite-env.d.ts", "@types", ".src/test/setup.ts"],


### PR DESCRIPTION
### 변경 사항
- 해당 이슈 해결
- vi undefined 오류 해결

### 고민과 해결 과정
#### 이슈 해결
원인은 최소 버튼을 누를시 window.close() 메서드가 호출되기 때문이었음.
즉, 함수의 파라미터로 close를 받았지만 정작 함수 안에서 구조분해 할당할 때 이를 사용하지 않아서 생기는 문제...
```tsx
function Component({value}: {close: () => void; value: string}) {
  const handler = () => {
    // ⚠️ window.close() 호출됨!
    close();
  };
  return ...
}
```
그래서 close라고 적혀있는 메소드명을 전부 closeXXX open이라고 적혀있는 메소드들은 openXXX라고 바꿔줌
나중에 close 키워드를 함수 이름으로 써야할 때 주의해야함

그리고 window.close는 원래 window.open으로 열린 페이지에 대해서만 작동한다고함
그래서 로컬 환경에서는 작동하지 않았는데 왜 배포하면 이 메서드가 작동하는지는 아직 찾아보는중

#### vi undefined 해결
아래처럼 __mocks__ 폴더 안에 있는 가짜모듈을 테스트 코드가 아닌 실제 코드에서 import해서 사용하고 있어서 생겼던 에러
```tsx
import WebRTC from '@business/services/__mocks__/WebRTC';
```
그래서 tsconfig.json에서 exclude 옵션으로 `__mocks__` 폴더를 제외 해주려고 했는데
그러면 테스트 코드를 작성 할 때도 vi를 찾지 못하는 문제가 생겨버림 어떻게 해야할지 생각  해 봐야할듯