### PR TITLE
FE/bugfix/#435 설정창에서만 내 목소리가 들리도록 수정함

### DIFF
--- a/frontend/src/pages/HumanChatPage/ChattingPage.tsx
+++ b/frontend/src/pages/HumanChatPage/ChattingPage.tsx
@@ -22,6 +22,13 @@ export function ChattingPage() {
     }
   }, [joinedRoom]);
 
+  useEffect(() => {
+    if (!localVideoRef.current) {
+      return;
+    }
+    localVideoRef.current.volume = 0;
+  }, []);
+
   const navigate = useNavigate();
   const goSettingPage = () => navigate('setting');
 


### PR DESCRIPTION
### 변경 사항
- 더이상 화면을 공유하는 화면에서 나의 목소리가 들리지 않음

### 고민과 해결 과정
대화할 때 내 목소리가 들리면 오히려 신경이 쓰이므로 자신의 목소리는 설정 페이지에서만 들리도록 수정함
간단하게 `<video>` 의 volume을 0으로 설정하면 됐음

close #435 