### PR TITLE
Be/feature/#522 데이터베이스 최적화

### DIFF
--- a/backend/was/src/auth/__mocks__/kakao.auth.service.ts
+++ b/backend/was/src/auth/__mocks__/kakao.auth.service.ts
@@ -8,7 +8,7 @@ import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Cache } from 'cache-manager';
 import { ERR_MSG } from 'src/common/constants/errors';
-import { PROVIDER_ID, PROVIDER_NAME } from 'src/common/constants/etc';
+import { ProviderIdEnum, ProviderName } from 'src/common/constants/etc';
 import { Member } from 'src/members/entities';
 import { Repository } from 'typeorm';
 import { JwtPayloadDto, OAuthTokenDto, ProfileDto } from '../dto';
@@ -59,7 +59,7 @@ export class MockedKakaoAuthService extends AuthService {
     readonly cacheManager: Cache,
   ) {
     super(jwtService, membersRepository, cacheManager);
-    this.init(PROVIDER_NAME.KAKAO);
+    this.init(ProviderName.KAKAO);
   }
 
   async loginOAuth(code: string): Promise<string> {
@@ -67,18 +67,18 @@ export class MockedKakaoAuthService extends AuthService {
     const profile: ProfileDto = this.getUser(token.access_token ?? '');
     const member: Member | null = await this.findMemberByEmail(
       profile.email,
-      PROVIDER_ID.KAKAO,
+      ProviderIdEnum.KAKAO,
     );
     if (member) {
       return this.login(
         member.id,
-        PROVIDER_ID.KAKAO,
+        ProviderIdEnum.KAKAO,
         profile,
         OAuthTokenDto.fromKakao(token),
       );
     }
     return this.signup(
-      PROVIDER_ID.KAKAO,
+      ProviderIdEnum.KAKAO,
       profile,
       OAuthTokenDto.fromKakao(token),
     );

--- a/backend/was/src/auth/auth.controller.ts
+++ b/backend/was/src/auth/auth.controller.ts
@@ -9,7 +9,7 @@ import {
 import { ApiTags } from '@nestjs/swagger';
 import * as dotenv from 'dotenv';
 import { Request, Response } from 'express';
-import { PROVIDER_ID } from 'src/common/constants/etc';
+import { ProviderIdEnum } from 'src/common/constants/etc';
 import {
   AuthenticateDecorator,
   KakaoLoginDecorator,
@@ -60,12 +60,12 @@ export class AuthController {
   async kakaoLogout(@Req() req: any, @Res() res: Response): Promise<void> {
     const user: JwtPayloadDto = req.user;
     switch (user.providerId) {
-      case PROVIDER_ID.KAKAO:
+      case ProviderIdEnum.KAKAO:
         await this.kakaoAuthService.logoutOAuth(user);
         break;
-      case PROVIDER_ID.NAVER:
+      case ProviderIdEnum.NAVER:
         break;
-      case PROVIDER_ID.GOOGLE:
+      case ProviderIdEnum.GOOGLE:
         break;
     }
     res.clearCookie('magicconch');

--- a/backend/was/src/auth/service/auth.service.spec.ts
+++ b/backend/was/src/auth/service/auth.service.spec.ts
@@ -3,7 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import * as dotenv from 'dotenv';
 import { RedisCacheModule } from 'src/common/config/cache/redis-cache.module';
-import { PROVIDER_ID } from 'src/common/constants/etc';
+import { ProviderIdEnum } from 'src/common/constants/etc';
 import { CreateMemberDto, UpdateMemberDto } from 'src/members/dto';
 import { Member } from 'src/members/entities';
 import { Repository } from 'typeorm';
@@ -67,17 +67,17 @@ describe('AuthService', () => {
     it('신규회원은 회원가입 할 수 있다.', async () => {
       [
         {
-          providerId: PROVIDER_ID.KAKAO,
+          providerId: ProviderIdEnum.KAKAO,
           profile: profileDto,
           token: oauthTokenDto,
         },
         {
-          providerId: PROVIDER_ID.NAVER,
+          providerId: ProviderIdEnum.NAVER,
           profile: profileDto,
           token: oauthTokenDto,
         },
         {
-          providerId: PROVIDER_ID.GOOGLE,
+          providerId: ProviderIdEnum.GOOGLE,
           profile: profileDto,
           token: oauthTokenDto,
         },
@@ -105,19 +105,19 @@ describe('AuthService', () => {
       [
         {
           id: 'id1',
-          providerId: PROVIDER_ID.KAKAO,
+          providerId: ProviderIdEnum.KAKAO,
           profile: profileDto,
           token: oauthTokenDto,
         },
         {
           id: 'id2',
-          providerId: PROVIDER_ID.NAVER,
+          providerId: ProviderIdEnum.NAVER,
           profile: profileDto,
           token: oauthTokenDto,
         },
         {
           id: 'id3',
-          providerId: PROVIDER_ID.GOOGLE,
+          providerId: ProviderIdEnum.GOOGLE,
           profile: profileDto,
           token: oauthTokenDto,
         },

--- a/backend/was/src/auth/service/auth.service.ts
+++ b/backend/was/src/auth/service/auth.service.ts
@@ -103,9 +103,12 @@ export class AuthService {
     providerId: number,
   ): Promise<Member | null> {
     try {
-      return await this.membersRepository.findOneBy({
-        email: email,
-        providerId: providerId,
+      return await this.membersRepository.findOne({
+        where: {
+          email: email,
+          providerId: providerId,
+        },
+        select: ['id'],
       });
     } catch (err: unknown) {
       throw err;

--- a/backend/was/src/auth/service/kakao.auth.service.ts
+++ b/backend/was/src/auth/service/kakao.auth.service.ts
@@ -11,7 +11,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Cache } from 'cache-manager';
 import { CONTENT_TYPE, METHODS, OAUTH_URL } from 'src/common/constants/apis';
 import { ERR_MSG } from 'src/common/constants/errors';
-import { PROVIDER_ID, PROVIDER_NAME } from 'src/common/constants/etc';
+import { ProviderIdEnum } from 'src/common/constants/etc';
 import { Member } from 'src/members/entities';
 import { Repository } from 'typeorm';
 import { JwtPayloadDto, OAuthTokenDto, ProfileDto } from '../dto';
@@ -30,7 +30,7 @@ export class KakaoAuthService extends AuthService {
     readonly cacheManager: Cache,
   ) {
     super(jwtService, membersRepository, cacheManager);
-    this.init(PROVIDER_NAME.KAKAO);
+    this.init('KAKAO');
   }
 
   async loginOAuth(code: string): Promise<string> {
@@ -38,18 +38,18 @@ export class KakaoAuthService extends AuthService {
     const profile: ProfileDto = await this.getUser(token.access_token ?? '');
     const member: Member | null = await this.findMemberByEmail(
       profile.email,
-      PROVIDER_ID.KAKAO,
+      ProviderIdEnum.KAKAO,
     );
     if (member) {
       return this.login(
         member.id,
-        PROVIDER_ID.KAKAO,
+        ProviderIdEnum.KAKAO,
         profile,
         OAuthTokenDto.fromKakao(token),
       );
     }
     return this.signup(
-      PROVIDER_ID.KAKAO,
+      ProviderIdEnum.KAKAO,
       profile,
       OAuthTokenDto.fromKakao(token),
     );

--- a/backend/was/src/chat/chat.service.spec.ts
+++ b/backend/was/src/chat/chat.service.spec.ts
@@ -1,6 +1,6 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { PROVIDER_ID } from 'src/common/constants/etc';
+import { ProviderIdEnum } from 'src/common/constants/etc';
 import { ChatLog } from 'src/common/types/chatbot';
 import { UserInfo } from 'src/common/types/socket';
 import { Member } from 'src/members/entities';
@@ -82,13 +82,13 @@ describe('ChatService', () => {
           {
             memberId: '12345678-1234-5678-1234-567812345670',
             email: 'tarotmilktea@kakao.com',
-            providerId: PROVIDER_ID.KAKAO,
+            providerId: ProviderIdEnum.KAKAO,
             roomId: '12345678-1234-5678-1234-567812345672',
           },
           {
             memberId: '12345678-1234-5678-1234-567812345671',
             email: 'tarotmilktea2@kakao.com',
-            providerId: PROVIDER_ID.KAKAO,
+            providerId: ProviderIdEnum.KAKAO,
             roomId: '12345678-1234-5678-1234-567812345673',
           },
         ];
@@ -196,7 +196,7 @@ describe('ChatService', () => {
       const member: Member = {
         id: '12345678-1234-5678-1234-567812345670',
         email: 'tarotmilktea@kakao.com',
-        providerId: PROVIDER_ID.KAKAO,
+        providerId: ProviderIdEnum.KAKAO,
       };
       const rooms: ChattingRoom[] = [
         {
@@ -246,7 +246,7 @@ describe('ChatService', () => {
       member = {
         id: '12345678-1234-5678-1234-567812345670',
         email: 'tarotmilktea@kakao.com',
-        providerId: PROVIDER_ID.KAKAO,
+        providerId: ProviderIdEnum.KAKAO,
       };
 
       room = {
@@ -321,7 +321,7 @@ describe('ChatService', () => {
         const forbiddenMember: Member = {
           id: '12345678-0000-0000-1234-567812345678',
           email: 'tarotmilktea2@kakao.com',
-          providerId: PROVIDER_ID.KAKAO,
+          providerId: ProviderIdEnum.KAKAO,
         };
 
         const transactionMock = jest
@@ -351,7 +351,7 @@ describe('ChatService', () => {
       member = {
         id: '12345678-1234-5678-1234-567812345670',
         email: 'tarotmilktea@kakao.com',
-        providerId: PROVIDER_ID.KAKAO,
+        providerId: ProviderIdEnum.KAKAO,
       };
 
       room = {
@@ -405,7 +405,7 @@ describe('ChatService', () => {
         const forbiddenMember: Member = {
           id: '12345678-0000-0000-1234-567812345678',
           email: 'tarotmilktea2@kakao.com',
-          providerId: PROVIDER_ID.KAKAO,
+          providerId: ProviderIdEnum.KAKAO,
         };
 
         const transactionMock = jest
@@ -435,7 +435,7 @@ describe('ChatService', () => {
       member = {
         id: '12345678-1234-5678-1234-567812345670',
         email: 'tarotmilktea@kakao.com',
-        providerId: PROVIDER_ID.KAKAO,
+        providerId: ProviderIdEnum.KAKAO,
       };
 
       room = {
@@ -483,7 +483,7 @@ describe('ChatService', () => {
         const forbiddenMember: Member = {
           id: '12345678-0000-0000-1234-567812345678',
           email: 'tarotmilktea2@kakao.com',
-          providerId: PROVIDER_ID.KAKAO,
+          providerId: ProviderIdEnum.KAKAO,
         };
 
         const transactionMock = jest

--- a/backend/was/src/chat/chat.service.ts
+++ b/backend/was/src/chat/chat.service.ts
@@ -32,8 +32,8 @@ export class ChatService {
     memberId: string,
     createMessageDtos: CreateChattingMessageDto[],
   ): Promise<void> {
-    try {
-      return this.entityManager.transaction(async (manager: EntityManager) => {
+    return this.entityManager.transaction(async (manager: EntityManager) => {
+      try {
         const room: ChattingRoom = await this.findRoomById(
           manager,
           id,
@@ -44,18 +44,18 @@ export class ChatService {
             ChattingMessage.fromDto(createMessageDto, room),
         );
         await manager.insert(ChattingMessage, messages);
-      });
-    } catch (err: unknown) {
-      throw err;
-    }
+      } catch (err: unknown) {
+        throw err;
+      }
+    });
   }
 
   async findRoomsByEmail(
     email: string,
     providerId: number,
   ): Promise<ChattingRoomDto[]> {
-    try {
-      return this.entityManager.transaction(async (manager: EntityManager) => {
+    return this.entityManager.transaction(async (manager: EntityManager) => {
+      try {
         const member: Member = await this.findMemberByEmail(
           manager,
           email,
@@ -71,10 +71,10 @@ export class ChatService {
           (room: ChattingRoom): ChattingRoomDto =>
             ChattingRoomDto.fromEntity(room),
         );
-      });
-    } catch (err: unknown) {
-      throw err;
-    }
+      } catch (err: unknown) {
+        throw err;
+      }
+    });
   }
 
   async findMessagesById(
@@ -82,8 +82,8 @@ export class ChatService {
     email: string,
     providerId: number,
   ): Promise<ChattingMessageDto[]> {
-    try {
-      return this.entityManager.transaction(async (manager: EntityManager) => {
+    return this.entityManager.transaction(async (manager: EntityManager) => {
+      try {
         const member: Member = await this.findMemberByEmail(
           manager,
           email,
@@ -101,10 +101,10 @@ export class ChatService {
           (message: ChattingMessage): ChattingMessageDto =>
             ChattingMessageDto.fromEntity(message),
         );
-      });
-    } catch (err: unknown) {
-      throw err;
-    }
+      } catch (err: unknown) {
+        throw err;
+      }
+    });
   }
 
   async updateRoom(
@@ -113,8 +113,8 @@ export class ChatService {
     providerId: number,
     updateChattingRoomDto: UpdateChattingRoomDto,
   ): Promise<void> {
-    try {
-      return this.entityManager.transaction(async (manager: EntityManager) => {
+    return this.entityManager.transaction(async (manager: EntityManager) => {
+      try {
         const member: Member = await this.findMemberByEmail(
           manager,
           email,
@@ -126,10 +126,10 @@ export class ChatService {
           { id: id },
           { title: updateChattingRoomDto.title },
         );
-      });
-    } catch (err: unknown) {
-      throw err;
-    }
+      } catch (err: unknown) {
+        throw err;
+      }
+    });
   }
 
   async removeRoom(
@@ -137,8 +137,8 @@ export class ChatService {
     email: string,
     providerId: number,
   ): Promise<void> {
-    try {
-      return this.entityManager.transaction(async (manager: EntityManager) => {
+    return this.entityManager.transaction(async (manager: EntityManager) => {
+      try {
         const member: Member = await this.findMemberByEmail(
           manager,
           email,
@@ -146,18 +146,18 @@ export class ChatService {
         );
         await this.findRoomById(manager, id, member.id);
         await manager.softDelete(ChattingRoom, { id: id });
-      });
-    } catch (err: unknown) {
-      throw err;
-    }
+      } catch (err: unknown) {
+        throw err;
+      }
+    });
   }
 
   private async createRoomForMember(
     email: string,
     providerId: number,
   ): Promise<ChattingInfo> {
-    try {
-      return this.entityManager.transaction(async (manager: EntityManager) => {
+    return this.entityManager.transaction(async (manager: EntityManager) => {
+      try {
         const member: Member = await this.findMemberByEmail(
           manager,
           email,
@@ -168,25 +168,25 @@ export class ChatService {
           ChattingRoom.fromMember(member),
         );
         return { memberId: member.id, roomId: room.id };
-      });
-    } catch (err: unknown) {
-      throw err;
-    }
+      } catch (err: unknown) {
+        throw err;
+      }
+    });
   }
 
   private async createRoomForNonMember(): Promise<ChattingInfo> {
-    try {
-      return this.entityManager.transaction(async (manager: EntityManager) => {
+    return this.entityManager.transaction(async (manager: EntityManager) => {
+      try {
         const member: Member = await manager.save(Member, new Member());
         const room = await manager.save(
           ChattingRoom,
           ChattingRoom.fromMember(member),
         );
         return { memberId: member.id, roomId: room.id };
-      });
-    } catch (err: unknown) {
-      throw err;
-    }
+      } catch (err: unknown) {
+        throw err;
+      }
+    });
   }
 
   private async findRoomById(

--- a/backend/was/src/chat/chat.service.ts
+++ b/backend/was/src/chat/chat.service.ts
@@ -67,8 +67,11 @@ export class ChatService {
         email,
         providerId,
       );
-      const rooms: ChattingRoom[] = await this.chattingRoomRepository.findBy({
-        participant: { id: memberId },
+      const rooms: ChattingRoom[] = await this.chattingRoomRepository.find({
+        where: {
+          participant: { id: memberId },
+        },
+        select: ['id', 'title'],
       });
       return rooms.map((room: ChattingRoom) =>
         ChattingRoomDto.fromEntity(room),
@@ -90,7 +93,10 @@ export class ChatService {
       );
       await this.findRoom(id, memberId);
       const messages: ChattingMessage[] =
-        await this.chattingMessageRepository.findBy({ room: { id: id } });
+        await this.chattingMessageRepository.find({
+          where: { room: { id: id } },
+          select: ['isHost', 'message'],
+        });
       return messages.map((message: ChattingMessage) =>
         ChattingMessageDto.fromEntity(message),
       );
@@ -142,9 +148,12 @@ export class ChatService {
     providerId: number,
   ): Promise<ChattingInfo> {
     try {
-      const member: Member | null = await this.membersRepository.findOneBy({
-        email: email,
-        providerId: providerId,
+      const member: Member | null = await this.membersRepository.findOne({
+        where: {
+          email: email,
+          providerId: providerId,
+        },
+        select: ['id'],
       });
       if (!member) {
         throw new BadRequestException();
@@ -171,8 +180,12 @@ export class ChatService {
   }
 
   private async findRoom(id: string, memberId: string): Promise<ChattingRoom> {
-    const room: ChattingRoom | null =
-      await this.chattingRoomRepository.findOneBy({ id: id });
+    const room: ChattingRoom | null = await this.chattingRoomRepository.findOne(
+      {
+        where: { id: id },
+        select: ['id', 'participant'],
+      },
+    );
     if (!room) {
       throw new NotFoundException(ERR_MSG.CHATTING_ROOM_NOT_FOUND);
     }
@@ -186,9 +199,12 @@ export class ChatService {
     email: string,
     providerId: number,
   ): Promise<string> {
-    const member: Member | null = await this.membersRepository.findOneBy({
-      email: email,
-      providerId: providerId,
+    const member: Member | null = await this.membersRepository.findOne({
+      where: {
+        email: email,
+        providerId: providerId,
+      },
+      select: ['id'],
     });
     if (!member) {
       throw new BadRequestException();

--- a/backend/was/src/chat/chat.service.ts
+++ b/backend/was/src/chat/chat.service.ts
@@ -43,7 +43,7 @@ export class ChatService {
           (createMessageDto: CreateChattingMessageDto): ChattingMessage =>
             ChattingMessage.fromDto(createMessageDto, room),
         );
-        await manager.save(ChattingMessage, messages);
+        await manager.insert(ChattingMessage, messages);
       });
     } catch (err: unknown) {
       throw err;

--- a/backend/was/src/chat/chatting-info.interface.ts
+++ b/backend/was/src/chat/chatting-info.interface.ts
@@ -1,0 +1,4 @@
+export interface ChattingInfo {
+  memberId: string;
+  roomId: string;
+}

--- a/backend/was/src/chat/entities/chatting-message.entity.ts
+++ b/backend/was/src/chat/entities/chatting-message.entity.ts
@@ -17,7 +17,7 @@ export class ChattingMessage {
   @Column('boolean')
   isHost: boolean;
 
-  @Column({ length: 1000 })
+  @Column({ length: 1000, nullable: false })
   message: string;
 
   @CreateDateColumn()

--- a/backend/was/src/chat/entities/chatting-room.entity.ts
+++ b/backend/was/src/chat/entities/chatting-room.entity.ts
@@ -25,7 +25,7 @@ export class ChattingRoom {
   @UpdateDateColumn()
   updatedAt?: Date;
 
-  @DeleteDateColumn({ name: 'deletedAt', nullable: true })
+  @DeleteDateColumn({ name: 'deleted_at', nullable: true })
   deletedAt?: Date;
 
   @OneToMany(() => ChattingMessage, (chattingMessage) => chattingMessage.id)

--- a/backend/was/src/chat/entities/chatting-room.entity.ts
+++ b/backend/was/src/chat/entities/chatting-room.entity.ts
@@ -16,7 +16,7 @@ export class ChattingRoom {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ nullable: true })
+  @Column({ length: 30, nullable: true })
   title?: string;
 
   @CreateDateColumn()

--- a/backend/was/src/common/constants/etc.ts
+++ b/backend/was/src/common/constants/etc.ts
@@ -1,16 +1,21 @@
 export const BUCKET_URL: string =
   'https://kr.object.ncloudstorage.com/magicconch';
 
-type Provider = 'KAKAO' | 'NAVER' | 'GOOGLE';
+export enum ProviderName {
+  KAKAO = 'KAKAO',
+  NAVER = 'NAVER',
+  GOOGLE = 'GOOGLE',
+}
 
-export const PROVIDER_ID: Record<Provider, number> = {
-  KAKAO: 0,
-  NAVER: 1,
-  GOOGLE: 2,
-};
+export enum ProviderIdEnum {
+  KAKAO = 0,
+  NAVER = 1,
+  GOOGLE = 2,
+}
 
-export const PROVIDER_NAME: Record<Provider, Provider> = {
-  KAKAO: 'KAKAO',
-  NAVER: 'NAVER',
-  GOOGLE: 'GOOGLE',
-};
+export enum ExtEnum {
+  JPG = 0,
+  PNG = 1,
+}
+
+export const ExtArray = Object.values(ExtEnum);

--- a/backend/was/src/members/dto/create-member.dto.ts
+++ b/backend/was/src/members/dto/create-member.dto.ts
@@ -7,14 +7,14 @@ import {
   IsUrl,
 } from 'class-validator';
 import { ProfileDto } from 'src/auth/dto';
-import { PROVIDER_ID } from 'src/common/constants/etc';
+import { ProviderIdEnum } from 'src/common/constants/etc';
 
 export class CreateMemberDto {
   @IsEmail()
   readonly email: string;
 
   @IsInt()
-  @IsIn(Object.values(PROVIDER_ID))
+  @IsIn(Object.values(ProviderIdEnum))
   readonly providerId: number;
 
   @IsString()

--- a/backend/was/src/members/entities/member.entity.ts
+++ b/backend/was/src/members/entities/member.entity.ts
@@ -34,7 +34,7 @@ export class Member {
   @UpdateDateColumn()
   updatedAt?: Date;
 
-  @DeleteDateColumn({ name: 'deletedAt', nullable: true })
+  @DeleteDateColumn({ name: 'deleted_at', nullable: true })
   deletedAt?: Date;
 
   @OneToMany(() => ChattingRoom, (chattingRoom) => chattingRoom.participant)

--- a/backend/was/src/members/entities/member.entity.ts
+++ b/backend/was/src/members/entities/member.entity.ts
@@ -19,7 +19,7 @@ export class Member {
   @Column({ length: 320, nullable: true })
   email?: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'tinyint', nullable: true })
   providerId?: number;
 
   @Column({ length: 30, nullable: true })

--- a/backend/was/src/members/entities/member.entity.ts
+++ b/backend/was/src/members/entities/member.entity.ts
@@ -1,4 +1,5 @@
 import { ChattingRoom } from 'src/chat/entities';
+import { ProviderIdEnum } from 'src/common/constants/etc';
 import { TarotCardPack } from 'src/tarot/entities';
 import {
   Column,
@@ -20,7 +21,7 @@ export class Member {
   email?: string;
 
   @Column({ type: 'tinyint', nullable: true })
-  providerId?: number;
+  providerId?: ProviderIdEnum;
 
   @Column({ length: 30, nullable: true })
   nickname?: string;

--- a/backend/was/src/tarot/dto/tarot-card.dto.ts
+++ b/backend/was/src/tarot/dto/tarot-card.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsUrl } from 'class-validator';
-import { BUCKET_URL } from 'src/common/constants/etc';
+import { BUCKET_URL, ExtArray } from 'src/common/constants/etc';
 import { TarotCard } from '../entities';
 
 export class TarotCardDto {
@@ -9,6 +9,9 @@ export class TarotCardDto {
   readonly cardUrl: string;
 
   static fromEntity(entity: TarotCard): TarotCardDto {
-    return { cardUrl: `${BUCKET_URL}/basic/${entity.cardNo}${entity.ext}` };
+    const extStr: string = ExtArray[entity.ext] as string;
+    return {
+      cardUrl: `${BUCKET_URL}/basic/${entity.cardNo}.${extStr.toLowerCase()}`,
+    };
   }
 }

--- a/backend/was/src/tarot/entities/tarot-card.entity.ts
+++ b/backend/was/src/tarot/entities/tarot-card.entity.ts
@@ -26,7 +26,7 @@ export class TarotCard {
   @UpdateDateColumn()
   updatedAt?: Date;
 
-  @DeleteDateColumn({ name: 'deletedAt', nullable: true })
+  @DeleteDateColumn({ name: 'deleted_at', nullable: true })
   deletedAt?: Date;
 
   @ManyToOne(() => TarotCardPack, (tarotCardPack) => tarotCardPack.tarotCards)

--- a/backend/was/src/tarot/entities/tarot-card.entity.ts
+++ b/backend/was/src/tarot/entities/tarot-card.entity.ts
@@ -14,7 +14,7 @@ export class TarotCard {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column('int')
+  @Column('tinyint')
   cardNo: number;
 
   @Column({ length: 10 })

--- a/backend/was/src/tarot/entities/tarot-card.entity.ts
+++ b/backend/was/src/tarot/entities/tarot-card.entity.ts
@@ -1,3 +1,4 @@
+import { ExtEnum } from 'src/common/constants/etc';
 import {
   Column,
   CreateDateColumn,
@@ -17,8 +18,8 @@ export class TarotCard {
   @Column('tinyint')
   cardNo: number;
 
-  @Column({ length: 10 })
-  ext: string;
+  @Column({ type: 'tinyint' })
+  ext: ExtEnum;
 
   @CreateDateColumn()
   createdAt?: Date;

--- a/backend/was/src/tarot/entities/tarot-result.entity.ts
+++ b/backend/was/src/tarot/entities/tarot-result.entity.ts
@@ -15,7 +15,7 @@ export class TarotResult {
   @Column({ length: 255 })
   cardUrl: string;
 
-  @Column({ type: 'text' })
+  @Column({ length: 1000 })
   message: string;
 
   @CreateDateColumn()

--- a/backend/was/src/tarot/tarot.service.spec.ts
+++ b/backend/was/src/tarot/tarot.service.spec.ts
@@ -1,7 +1,7 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { BUCKET_URL } from 'src/common/constants/etc';
+import { BUCKET_URL, ExtEnum } from 'src/common/constants/etc';
 import { Repository } from 'typeorm';
 import { CreateTarotResultDto, TarotCardDto, TarotResultDto } from './dto';
 import { TarotCard, TarotResult } from './entities';
@@ -95,17 +95,17 @@ describe('TarotService', () => {
         {
           id: '12345678-1234-5678-1234-567812345670',
           cardNo: 0,
-          ext: '.jpg',
+          ext: ExtEnum.JPG,
         },
         {
           id: '12345678-1234-5678-1234-567812345671',
           cardNo: 1,
-          ext: '.jpg',
+          ext: ExtEnum.JPG,
         },
         {
           id: '12345678-1234-5678-1234-567812345672',
           cardNo: 2,
-          ext: '.jpg',
+          ext: ExtEnum.JPG,
         },
       ].forEach(async ({ id, cardNo, ext }) => {
         const tarotCard: TarotCard = {

--- a/backend/was/src/tarot/tarot.service.spec.ts
+++ b/backend/was/src/tarot/tarot.service.spec.ts
@@ -115,32 +115,38 @@ describe('TarotService', () => {
         };
         const tarotCardDto: TarotCardDto = TarotCardDto.fromEntity(tarotCard);
 
-        const findOneByMock = jest
-          .spyOn(tarotCardRepository, 'findOneBy')
+        const findOneMock = jest
+          .spyOn(tarotCardRepository, 'findOne')
           .mockResolvedValueOnce(tarotCard);
 
         const expectation: TarotCardDto =
           await tarotService.findTarotCardByCardNo(tarotCard.cardNo);
         expect(expectation).toEqual(tarotCardDto);
-        expect(findOneByMock).toHaveBeenCalledWith({
-          cardNo: cardNo,
-          cardPack: undefined,
+        expect(findOneMock).toHaveBeenCalledWith({
+          where: {
+            cardNo: cardNo,
+            cardPack: undefined,
+          },
+          select: ['cardNo', 'ext', 'cardPack'],
         });
       });
     });
 
     it('해당 번호의 타로 카드가 존재하지 않아 NotFoundException을 반환한다.', async () => {
       [{ cardNo: -1 }, { cardNo: 79 }].forEach(async ({ cardNo }) => {
-        const findOneByMock = jest
-          .spyOn(tarotCardRepository, 'findOneBy')
+        const findOneMock = jest
+          .spyOn(tarotCardRepository, 'findOne')
           .mockResolvedValueOnce(null);
 
         await expect(
           tarotService.findTarotCardByCardNo(cardNo),
         ).rejects.toThrow(NotFoundException);
-        expect(findOneByMock).toHaveBeenCalledWith({
-          cardNo: cardNo,
-          cardPack: undefined,
+        expect(findOneMock).toHaveBeenCalledWith({
+          where: {
+            cardNo: cardNo,
+            cardPack: undefined,
+          },
+          select: ['cardNo', 'ext', 'cardPack'],
         });
       });
     });
@@ -172,14 +178,17 @@ describe('TarotService', () => {
         };
         const tarotResultDto = TarotResultDto.fromEntity(tarotResult);
 
-        const findOneByMock = jest
-          .spyOn(tarotResultRepository, 'findOneBy')
+        const findOneMock = jest
+          .spyOn(tarotResultRepository, 'findOne')
           .mockResolvedValueOnce(tarotResult);
 
         const expectation: TarotResultDto =
           await tarotService.findTarotResultById(id);
         expect(expectation).toEqual(tarotResultDto);
-        expect(findOneByMock).toHaveBeenCalledWith({ id: id });
+        expect(findOneMock).toHaveBeenCalledWith({
+          where: { id: id },
+          select: ['cardUrl', 'message'],
+        });
       });
     });
 
@@ -188,14 +197,17 @@ describe('TarotService', () => {
         { id: '12345678-1234-5678-1234-567812345670' },
         { id: '12345678-1234-5678-1234-567812345671' },
       ].forEach(async ({ id }) => {
-        const findOneByMock = jest
-          .spyOn(tarotResultRepository, 'findOneBy')
+        const findOneMock = jest
+          .spyOn(tarotResultRepository, 'findOne')
           .mockResolvedValueOnce(null);
 
         await expect(tarotService.findTarotResultById(id)).rejects.toThrow(
           NotFoundException,
         );
-        expect(findOneByMock).toHaveBeenCalledWith({ id: id });
+        expect(findOneMock).toHaveBeenCalledWith({
+          where: { id: id },
+          select: ['cardUrl', 'message'],
+        });
       });
     });
   });

--- a/backend/was/src/tarot/tarot.service.ts
+++ b/backend/was/src/tarot/tarot.service.ts
@@ -33,10 +33,14 @@ export class TarotService {
   async findTarotCardByCardNo(cardNo: number): Promise<TarotCardDto> {
     try {
       const tarotCard: TarotCard | null =
-        await this.tarotCardRepository.findOneBy({
-          cardNo: cardNo,
-          cardPack: undefined,
+        await this.tarotCardRepository.findOne({
+          where: {
+            cardNo: cardNo,
+            cardPack: undefined,
+          },
+          select: ['cardNo', 'ext', 'cardPack'],
         });
+
       if (!tarotCard) {
         throw new NotFoundException(ERR_MSG.TAROT_CARD_NOT_FOUND);
       }
@@ -49,7 +53,10 @@ export class TarotService {
   async findTarotResultById(id: string): Promise<TarotResultDto> {
     try {
       const tarotResult: TarotResult | null =
-        await this.tarotResultRepository.findOneBy({ id: id });
+        await this.tarotResultRepository.findOne({
+          where: { id: id },
+          select: ['cardUrl', 'message'],
+        });
       if (!tarotResult) {
         throw new NotFoundException(ERR_MSG.TAROT_RESULT_NOT_FOUND);
       }

--- a/backend/was/test/chat.e2e-spec.ts
+++ b/backend/was/test/chat.e2e-spec.ts
@@ -8,7 +8,7 @@ import { ChatController } from 'src/chat/chat.controller';
 import { ChatService } from 'src/chat/chat.service';
 import { ChattingMessageDto, UpdateChattingRoomDto } from 'src/chat/dto';
 import { ChattingMessage, ChattingRoom } from 'src/chat/entities';
-import { PROVIDER_ID } from 'src/common/constants/etc';
+import { ProviderIdEnum } from 'src/common/constants/etc';
 import { Member } from 'src/members/entities';
 import * as request from 'supertest';
 import { EntityManager } from 'typeorm';
@@ -40,12 +40,12 @@ describe('Chat', () => {
 
     const member: Member = new Member();
     member.email = 'tarotmilktea@kakao.com';
-    member.providerId = PROVIDER_ID.KAKAO;
+    member.providerId = ProviderIdEnum.KAKAO;
     await entityManager.save(member);
 
     const diffMember: Member = new Member();
     diffMember.email = 'tarotmilktea2@kakako.com';
-    diffMember.providerId = PROVIDER_ID.KAKAO;
+    diffMember.providerId = ProviderIdEnum.KAKAO;
     await entityManager.save(diffMember);
 
     const room: ChattingRoom = new ChattingRoom();

--- a/backend/was/test/tarot.e2e-spec.ts
+++ b/backend/was/test/tarot.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { BUCKET_URL } from 'src/common/constants/etc';
+import { BUCKET_URL, ExtEnum } from 'src/common/constants/etc';
 import { TarotCard, TarotCardPack, TarotResult } from 'src/tarot/entities';
 import { TarotController } from 'src/tarot/tarot.controller';
 import { TarotService } from 'src/tarot/tarot.service';
@@ -42,7 +42,7 @@ describe('Tarot', () => {
     beforeAll(async () => {
       const tarotCard: TarotCard = new TarotCard();
       tarotCard.cardNo = 0;
-      tarotCard.ext = '.jpg';
+      tarotCard.ext = ExtEnum.JPG;
       await entityManager.save(tarotCard);
     });
 


### PR DESCRIPTION
### 변경 사항
- 커버링 인덱스를 활용하기 위해 정말 필요한 컬럼만 조회하도록 수정
- 불필요한 쿼리 삭제 (ex. `save`시 `INSERT` 후 `SELECT`가 수행됨)
- 트랜잭션 오버헤드 방지
- 데이터 타입 수정

### 고민과 해결 과정

#### 1️⃣ 트랜잭션 적용하기
mysql은 기본적으로 `AUTOCOMMIT`이 1로 설정되어 있다. 이로 인해 개별 sql문이 트랜잭션으로 취급되고 트랜잭션의 시작과 끝에 오버헤드가 발생하여 성능이 저하될 수 있다.

따라서 연관된 쿼리를 하나의 트랜잭션으로 묶어 오버헤드를 줄여줄 것이다. 다음 코드는 한 번에 여러 개의 쿼리를 일괄로 실행하는 함수인데, 트랜잭션을 사용하지 않아 각각의 `save` 작업이 개별적인 트랜잭션으로 처리된다. 실행 시 약 395 밀리초가 소요된다.

```ts
async saveMessages(
  room: ChattingRoom,
  createMessageDtos: CreateChattingMessageDto[],
): Promise<void> {
  const startTime = new Date();
  for (const createMessageDto of createMessageDtos) {
    const message: ChattingMessage = ChattingMessage.fromDto(
      createMessageDto,
      room,
    );
    await this.chattingMessageRepository.save(message);
  }
  const endTime = new Date();
  const diff = endTime.getTime() - startTime.getTime();
  console.log(`findOneBy execution time: ${diff} milliseconds`);
}
```
```
[QUERY]: START TRANSACTION
[QUERY]: INSERT INTO `chatting_message`(`id`, `is_host`, `message`, `created_at`, `updated_at`, `room_id`) VALUES (?, ?, ?, DEFAULT, DEFAULT, ?) 
[QUERY]: SELECT `ChattingMessage`.`id` AS `ChattingMessage_id`, `ChattingMessage`.`created_at` AS `ChattingMessage_created_at`, `ChattingMessage`.`updated_at` AS `ChattingMessage_updated_at` FROM `chatting_message` `ChattingMessage` WHERE `ChattingMessage`.`id` = ? 
[QUERY]: COMMIT
[QUERY]: START TRANSACTION
[QUERY]: INSERT INTO `chatting_message`(`id`, `is_host`, `message`, `created_at`, `updated_at`, `room_id`) VALUES (?, ?, ?, DEFAULT, DEFAULT, ?) 
[QUERY]: SELECT `ChattingMessage`.`id` AS `ChattingMessage_id`, `ChattingMessage`.`created_at` AS `ChattingMessage_created_at`, `ChattingMessage`.`updated_at` AS `ChattingMessage_updated_at` FROM `chatting_message` `ChattingMessage` WHERE `ChattingMessage`.`id` = ? 
[QUERY]: COMMIT
[QUERY]: START TRANSACTION
[QUERY]: INSERT INTO `chatting_message`(`id`, `is_host`, `message`, `created_at`, `updated_at`, `room_id`) VALUES (?, ?, ?, DEFAULT, DEFAULT, ?) 
[QUERY]: SELECT `ChattingMessage`.`id` AS `ChattingMessage_id`, `ChattingMessage`.`created_at` AS `ChattingMessage_created_at`, `ChattingMessage`.`updated_at` AS `ChattingMessage_updated_at` FROM `chatting_message` `ChattingMessage` WHERE `ChattingMessage`.`id` = ?
[QUERY]: COMMIT
[QUERY]: START TRANSACTION
[QUERY]: INSERT INTO `chatting_message`(`id`, `is_host`, `message`, `created_at`, `updated_at`, `room_id`) VALUES (?, ?, ?, DEFAULT, DEFAULT, ?) 
[QUERY]: SELECT `ChattingMessage`.`id` AS `ChattingMessage_id`, `ChattingMessage`.`created_at` AS `ChattingMessage_created_at`, `ChattingMessage`.`updated_at` AS `ChattingMessage_updated_at` FROM `chatting_message` `ChattingMessage` WHERE `ChattingMessage`.`id` = ?
[QUERY]: COMMIT
[QUERY]: START TRANSACTION
[QUERY]: INSERT INTO `chatting_message`(`id`, `is_host`, `message`, `created_at`, `updated_at`, `room_id`) VALUES (?, ?, ?, DEFAULT, DEFAULT, ?) 
[QUERY]: SELECT `ChattingMessage`.`id` AS `ChattingMessage_id`, `ChattingMessage`.`created_at` AS `ChattingMessage_created_at`, `ChattingMessage`.`updated_at` AS `ChattingMessage_updated_at` FROM `chatting_message` `ChattingMessage` WHERE `ChattingMessage`.`id` = ? 
[QUERY]: COMMIT
[QUERY]: START TRANSACTION
[QUERY]: INSERT INTO `chatting_message`(`id`, `is_host`, `message`, `created_at`, `updated_at`, `room_id`) VALUES (?, ?, ?, DEFAULT, DEFAULT, ?) 
[QUERY]: SELECT `ChattingMessage`.`id` AS `ChattingMessage_id`, `ChattingMessage`.`created_at` AS `ChattingMessage_created_at`, `ChattingMessage`.`updated_at` AS `ChattingMessage_updated_at` FROM `chatting_message` `ChattingMessage` WHERE `ChattingMessage`.`id` = ? 
[QUERY]: COMMIT
```

`EntityManager`의 트랜잭션을 사용하여 모든 쿼리를 하나의 트랜잭션으로 묶었다. 모든 쿼리가 성공하면 커밋되고, 하나라도 실패하면 롤백하도록 수정했다. 트랜잭션을 활용함으로써 약 140밀리초가 줄어들었다.
```ts
async saveMessages(
  room: ChattingRoom,
  createMessageDtos: CreateChattingMessageDto[],
): Promise<void> {
  return this.entityManager.transaction(async (manager) => {
    try {
      const startTime = new Date();
      const messages: ChattingMessage[] = createMessageDtos.map(
        (createMessageDto: CreateChattingMessageDto): ChattingMessage =>
          ChattingMessage.fromDto(createMessageDto, room),
      );
      await manager.save(ChattingMessage, messages);
      const endTime = new Date();
      const diff = endTime.getTime() - startTime.getTime();
      console.log(`findOneBy execution time: ${diff} milliseconds`);
    } catch (err: unknown) {
      throw err;
    }
  });
}
```
```
[QUERY]: START TRANSACTION
[QUERY]: INSERT INTO `chatting_message`(`id`, `is_host`, `message`, `created_at`, `updated_at`, `room_id`) VALUES (?, ?, ?, DEFAULT, DEFAULT, ?) 
[QUERY]: SELECT `ChattingMessage`.`id` AS `ChattingMessage_id`, `ChattingMessage`.`created_at` AS `ChattingMessage_created_at`, `ChattingMessage`.`updated_at` AS `ChattingMessage_updated_at` FROM `chatting_message` `ChattingMessage` WHERE `ChattingMessage`.`id` = ? 
[QUERY]: INSERT INTO `chatting_message`(`id`, `is_host`, `message`, `created_at`, `updated_at`, `room_id`) VALUES (?, ?, ?, DEFAULT, DEFAULT, ?) 
[QUERY]: SELECT `ChattingMessage`.`id` AS `ChattingMessage_id`, `ChattingMessage`.`created_at` AS `ChattingMessage_created_at`, `ChattingMessage`.`updated_at` AS `ChattingMessage_updated_at` FROM `chatting_message` `ChattingMessage` WHERE `ChattingMessage`.`id` = ? 
[QUERY]: INSERT INTO `chatting_message`(`id`, `is_host`, `message`, `created_at`, `updated_at`, `room_id`) VALUES (?, ?, ?, DEFAULT, DEFAULT, ?) 
[QUERY]: SELECT `ChattingMessage`.`id` AS `ChattingMessage_id`, `ChattingMessage`.`created_at` AS `ChattingMessage_created_at`, `ChattingMessage`.`updated_at` AS `ChattingMessage_updated_at` FROM `chatting_message` `ChattingMessage` WHERE `ChattingMessage`.`id` = ?
[QUERY]: INSERT INTO `chatting_message`(`id`, `is_host`, `message`, `created_at`, `updated_at`, `room_id`) VALUES (?, ?, ?, DEFAULT, DEFAULT, ?) 
[QUERY]: SELECT `ChattingMessage`.`id` AS `ChattingMessage_id`, `ChattingMessage`.`created_at` AS `ChattingMessage_created_at`, `ChattingMessage`.`updated_at` AS `ChattingMessage_updated_at` FROM `chatting_message` `ChattingMessage` WHERE `ChattingMessage`.`id` = ?
[QUERY]: INSERT INTO `chatting_message`(`id`, `is_host`, `message`, `created_at`, `updated_at`, `room_id`) VALUES (?, ?, ?, DEFAULT, DEFAULT, ?) 
[QUERY]: SELECT `ChattingMessage`.`id` AS `ChattingMessage_id`, `ChattingMessage`.`created_at` AS `ChattingMessage_created_at`, `ChattingMessage`.`updated_at` AS `ChattingMessage_updated_at` FROM `chatting_message` `ChattingMessage` WHERE `ChattingMessage`.`id` = ? 
[QUERY]: INSERT INTO `chatting_message`(`id`, `is_host`, `message`, `created_at`, `updated_at`, `room_id`) VALUES (?, ?, ?, DEFAULT, DEFAULT, ?) 
[QUERY]: SELECT `ChattingMessage`.`id` AS `ChattingMessage_id`, `ChattingMessage`.`created_at` AS `ChattingMessage_created_at`, `ChattingMessage`.`updated_at` AS `ChattingMessage_updated_at` FROM `chatting_message` `ChattingMessage` WHERE `ChattingMessage`.`id` = ? 
[QUERY]: COMMIT
```
아까와 달리 모든 쿼리가 끝난 후에 커밋이 이루어지는 것을 확인할 수 있다.

#### 2️⃣ 불필요한 쿼리 삭제하기

위의 쿼리 로그를 보면 `INSERT` 후에 불필요한 `SELECT`가 발생하고 있다. 이는 TypeOrm의 `save` 때문이다. `save`는 insert 후에 select를 실행하여 삽입한 엔티티를 반환한다. select가 불필요한 경우 insert 메서드를 사용하여 불필요한 조회 작업을 하지 않아야 한다. 아래는 insert로 바꾼 후의 쿼리 로그다.

```
[QUERY]: START TRANSACTION
[QUERY]: INSERT INTO `chatting_message`(`id`, `is_host`, `message`, `created_at`, `updated_at`, `room_id`) VALUES (?, ?, ?, DEFAULT, DEFAULT, ?), (?, ?, ?, DEFAULT, DEFAULT, ?), (?, ?, ?, DEFAULT, DEFAULT, ?), (?, ?, ?, DEFAULT, DEFAULT, ?)
[QUERY]: COMMIT
```

#### 3️⃣ 데이터 타입 수정하기
데이터 크기를 최적화하여 디스크에 저장되는 데이터 양을 줄여야 한다. 따라서 작은 크기의 데이터 타입을 사용하여 디스크 공간과 메모리를 확보하도록 수정했다.

- 파일 확장자를 나타내는 `ext` 컬럼에 `enum` 적용
  - sqlite에서 enum을 지원하지 않아 `tinyint`와 ts의 `enum`으로 대체
- -128~127을 범위 내의 정수형에 대해 `tinyint` 적용
- `text` 대신 `varchar` 사용

### (선택) 테스트 결과

- 트랜잭션으로 연관된 작업을 묶어 불필요한 오버헤드 방지
- `insert`를 사용하여 불필요한 `SELECT` 작업 제거

| 트랜잭션 적용 전 & `save` 사용 | 트랜잭션 적용 후 & `save` 사용 | 트랜잭션 적용 후 & `insert` 사용 |
| --- | --- | --- |
| 약 395 밀리초 | 약 255 밀리초 | 약 89 밀리초 |
