### PR TITLE
Devops/bugfix/#549 pr 설정 액션이 멈추지 않음

### DIFF
--- a/.github/workflows/configure-pr.yml
+++ b/.github/workflows/configure-pr.yml
@@ -2,7 +2,7 @@ name: Configure PR When PR Opened
 
 on:
   pull_request:
-    types: ["opened"]
+    # types: ["opened"]
 
 permissions:
   contents: read
@@ -76,9 +76,11 @@ jobs:
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           script: |
             const sender = context.payload.sender.login;
+            console.log(sender);
             const assignees = context.payload.pull_request.assignees;
             const newAssignees = assignees ?? [];
             newAssignees.push(sender);
+            console.log(newAssignees);
 
             github.rest.issues.addAssignees({
               owner: context.repo.owner,

--- a/.github/workflows/configure-pr.yml
+++ b/.github/workflows/configure-pr.yml
@@ -2,7 +2,7 @@ name: Configure PR When PR Opened
 
 on:
   pull_request:
-    types: ["opened", "edited"]
+    types: ["opened"]
 
 permissions:
   contents: read

--- a/.github/workflows/configure-pr.yml
+++ b/.github/workflows/configure-pr.yml
@@ -2,7 +2,7 @@ name: Configure PR When PR Opened
 
 on:
   pull_request:
-    # types: ["opened"]
+    types: ["opened"]
 
 permissions:
   contents: read
@@ -76,11 +76,9 @@ jobs:
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           script: |
             const sender = context.payload.sender.login;
-            console.log(sender);
             const assignees = context.payload.pull_request.assignees;
             const newAssignees = assignees ?? [];
             newAssignees.push(sender);
-            console.log(newAssignees);
 
             github.rest.issues.addAssignees({
               owner: context.repo.owner,


### PR DESCRIPTION
🔮 resolved #549
### 변경 사항
액션을 트리거할 때 `opened`에 대해서만 트리거 되도록 설정

### 고민과 해결 과정
```yaml
on:
  pull_request:
    types: ["opened", "edited"]
```
PR이 열리거나 수정되면 액션이 트리거되도록 했는데 PR을 설정하는 과정이 곧 PR을 수정하는 작업이기 때문에 작업이 멈추지 않았다.

즉, 액션이 PR을 수정할 때마다 또 다른 액션을 트리거 하게 된다. 따라서 `edited`를 제거하여 이를 해결했다.
```diff
on:
  pull_request:
-    types: ["opened", "edited"]
+    types: ["opened"]
```

### (선택) 테스트 결과
