### PR TITLE
Devops/feature/#555 release drafter 도입

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,15 +10,15 @@ footer: |
   $CONTRIBUTORS
 categories:
   - title: "🚀 Features"
-    collapse-after: 10
+    collapse-after: 15
     labels:
       - "feature"
   - title: "🐛 Bug Fixes"
-    collapse-after: 10
+    collapse-after: 15
     labels:
       - "bug"
   - title: "🛠️ Improvement"
-    collapse-after: 10
+    collapse-after: 15
     labels:
       - "refactor"
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
@@ -34,7 +34,6 @@ version-resolver:
     labels:
       - "patch"
   default: patch
-
 replacers:
   - search: "/$(Be|Fe|Devops|Be,fe|Fe,be)/"
     replace: "[$1]"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,44 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+template: |
+  # Changes (v$RESOLVED_VERSION)
+
+  $CHANGES
+footer: |
+  ### Contributors
+
+  $CONTRIBUTORS
+categories:
+  - title: "🚀 Features"
+    collapse-after: 10
+    labels:
+      - "feature"
+  - title: "🐛 Bug Fixes"
+    collapse-after: 10
+    labels:
+      - "bug"
+  - title: "🛠️ Improvement"
+    collapse-after: 10
+    labels:
+      - "refactor"
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: '\<*_&#/@'
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+
+replacers:
+  - search: "/$(Be|Fe|Devops|Be,fe|Fe,be)/"
+    replace: "[$1]"
+  - search: "/(feature|bugfix|hotfix|refactor)(,(feature|bugfix|hotfix|refactor))/"
+    replace: "[$1$2]"
+  - search: "/"
+    replace: ""

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,7 +22,7 @@ categories:
     labels:
       - "refactor"
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
-change-title-escapes: '\<*_&#/@'
+change-title-escapes: '\<*_&#/@[]'
 version-resolver:
   major:
     labels:
@@ -40,4 +40,4 @@ replacers:
   - search: "/(feature|bugfix|hotfix|refactor)(,(feature|bugfix|hotfix|refactor))/"
     replace: "[$1$2]"
   - search: "/"
-    replace: ""
+    replace: " "

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,20 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - release
+
+permissions:
+  contents: read
+
+jobs:
+  update-release-draft:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
🔮 resolved #555
### 변경 사항
- `release` 브랜치로 푸시되었을 때 릴리즈 노트 초안을 작성하는 액션 작성
- 릴리즈 노트 초안을 위한 설정파일 작성

### 고민과 해결 과정
[release-drafter](https://github.com/release-drafter/release-drafter?tab=readme-ov-file)를 참고하여 다음과 같이 작성했다.
```yaml
name-template: "v$RESOLVED_VERSION"
tag-template: "v$RESOLVED_VERSION"
template: |
  # Changes (v$RESOLVED_VERSION)

  $CHANGES
footer: |
  ### Contributors

  $CONTRIBUTORS
categories:
  - title: "🚀 Features"
    collapse-after: 15
    labels:
      - "feature"
  - title: "🐛 Bug Fixes"
    collapse-after: 15
    labels:
      - "bug"
  - title: "🛠️ Improvement"
    collapse-after: 15
    labels:
      - "refactor"
change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
change-title-escapes: '\<*_&#/@[]'
...
replacers:
  - search: "/$(Be|Fe|Devops|Be,fe|Fe,be)/"
    replace: "[$1]"
  - search: "/(feature|bugfix|hotfix|refactor)(,(feature|bugfix|hotfix|refactor))/"
    replace: "[$1$2]"
  - search: "/"
    replace: " "
```
- 제목과 태그에 버전을 표기한다.
- 본문에 `changes`와 `contributors` 를 표기한다.
- 카테고리 크게 세 가지로 나뉜다.
  - Features : `feature` 라벨이 붙은 PR을 나열한다.
  - Bug Fixes : `bug` 라벨이 붙은 PR을 나열한다.
  - Improvement : `refactor` 라벨이 붙은 PR을 나열한다.
- `replacers` 옵션을 통해 문자열을 치환한다.

PR 제목의 경우, 다음과 같이 치환한다. 분야와 분류를 대괄호로 묶어 가독성을 개선했다. 
```markdown
Be,fe/bugfix,refactor/123 안녕
[Be,fe] [bugfix,refactor] #123 안녕
```
### (선택) 테스트 결과