### PR TITLE
Be/bugfix/#565 ssl 인증서 만료

### DIFF
--- a/.github/workflows/blue-green-cd.yml
+++ b/.github/workflows/blue-green-cd.yml
@@ -25,11 +25,6 @@ jobs:
           echo "${{ secrets.ENV_FILE }}" > .env
           echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" >> .env
           echo "GITHUB_SHA=${{ github.sha }}" >> .env
-          mkdir -p config/nginx/ssl/
-          echo "${{ secrets.SSL_OPTIONS }}" > config/nginx/ssl/options-ssl-nginx.conf
-          echo "${{ secrets.SSL_FULLCHAIN }}" > config/nginx/ssl/fullchain.pem
-          echo "${{ secrets.SSL_PRIVKEY }}" > config/nginx/ssl/privkey.pem
-          echo "${{ secrets.SSL_DHPARAMS }}" > config/nginx/ssl/ssl-dhparams.pem
 
       - name: Add Remote Host Key to known_hosts
         run: |
@@ -43,7 +38,7 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: ${{ secrets.SSH_PORT }}
-          source: "backend/.env,backend/deploy.sh,backend/send-slack-message.sh,backend/config,backend/compose.blue-deploy.yml,backend/compose.green-deploy.yml,backend/Dockerfile.nginx"
+          source: "backend/.env,backend/deploy.sh,backend/send-slack-message.sh,backend/compose.blue-deploy.yml,backend/compose.green-deploy.yml,backend/Dockerfile.nginx"
           target: "~/app/"
           overwrite: true
 

--- a/backend/Dockerfile.nginx
+++ b/backend/Dockerfile.nginx
@@ -2,9 +2,4 @@ FROM nginx:1.18.0
 
 COPY config/nginx/default.conf /etc/nginx/conf.d/default.conf
 
-COPY config/nginx/ssl/options-ssl-nginx.conf /etc/letsencrypt/options-ssl-nginx.conf
-COPY config/nginx/ssl/fullchain.pem /etc/letsencrypt/live/was.tarotmilktea.com/fullchain.pem
-COPY config/nginx/ssl/privkey.pem /etc/letsencrypt/live/was.tarotmilktea.com/privkey.pem
-COPY config/nginx/ssl/ssl-dhparams.pem /etc/letsencrypt/ssl-dhparams.pem
-
 CMD ["nginx", "-g", "daemon off;"]

--- a/backend/compose.blue-deploy.yml
+++ b/backend/compose.blue-deploy.yml
@@ -49,20 +49,12 @@ services:
     depends_on:
       - was-blue
       - signal-blue
-      - certbot
     volumes:
+      - /var/www/certbot:/var/www/certbot
+      - /etc/letsencrypt:/etc/letsencrypt
       - /var/log/nginx:/var/log/nginx
     networks:
       - backend
-
-  certbot:
-    image: certbot/certbot
-    volumes:
-      - /etc/letsencrypt
-      - /var/www/html:/var/www/html
-    networks:
-      - backend
-    command: certonly --webroot --webroot-path=/var/www/html -d was.tarotmilktea.com
 
 networks:
   backend:

--- a/backend/compose.green-deploy.yml
+++ b/backend/compose.green-deploy.yml
@@ -49,20 +49,12 @@ services:
     depends_on:
       - was-green
       - signal-green
-      - certbot
     volumes:
+      - /var/www/certbot:/var/www/certbot
+      - /etc/letsencrypt:/etc/letsencrypt
       - /var/log/nginx:/var/log/nginx
     networks:
       - backend
-
-  certbot:
-    image: certbot/certbot
-    volumes:
-      - /etc/letsencrypt
-      - /var/www/html:/var/www/html
-    networks:
-      - backend
-    command: certonly --webroot --webroot-path=/var/www/html -d was.tarotmilktea.com
 
 networks:
   backend:


### PR DESCRIPTION
🔮 resolved #565
### 변경 사항
- SSL 인증서 갱신
- 매월 SSL 인증서를 자동으로 갱신하는 스케줄링 작성
- 볼륨을 연결하여 SSL 관련 파일 복사 과정 삭제

### 고민과 해결 과정

#### 1️⃣ SSL 인증서 갱신
`net::ERR_CERT_DATE_INVALID` 에러를 해결하기 위해 SSL 인증서를 갱신했다. 기존에 작성한 docker-compose의 명령이 올바르지 않아 자동으로 갱신이 이루어지지 않았다.

docker-compose의 커맨드를 수정하는 것도 하나의 방법이지만, 매번 강제로 갱신을 하게 되면 갱신 횟수를 초과할 수 있기 때문에 호스트 서버에 certbot을 설치하여 ssl 인증서를 발급 받았다.

```bash
sudo apt install certbot
sudo certbot certonly \
--webroot --webroot-path=/var/www/certbot \
--email [email] \
--agree-tos \
--no-eff-email \ 
-d [domain]
```
위 명령을 실행하고 나면 `/etc/letsencrypt` 하위에 `keys`, `live` 등이 생긴다.

`options-ssl-nginx.conf`과 `ssl-dhparams.pem`도 생성하여 보안을 고려해줬다.
```
sudo openssl dhparam -out /etc/ssl/certs/ssl-dhparams.pem 2048
```
이제 더 이상 `net::ERR_CERT_DATE_INVALID` 에러가 발생하지 않는다.

#### 2️⃣ crontab에 SSL 인증서 갱신 등록하기
```
0 2 1 * * sudo certbot certonly --non-interactive --force-renewal --webroot --webroot-path=/var/www/certbot --email [email] --agree-tos --no-eff-email -d [domain] >> /var/log/certbot-renew.log 2>&1

```

- `0 2 1 * *` : 매월 1일 오전 2시에
- `sudo certbot ~` : 인증서 갱신하기

`--non-interactive`로 사용자 입력 없이 실행하고, `--force-renewal`을 통해 유효기간이 남아있더라도 무조건 갱신하도록 한다.

### (선택) 테스트 결과