### PR TITLE
Be/refactor/#569 api 커스텀 에러 정의

### DIFF
--- a/backend/was/src/auth/__mocks__/kakao.auth.service.ts
+++ b/backend/was/src/auth/__mocks__/kakao.auth.service.ts
@@ -1,14 +1,11 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import {
-  BadRequestException,
-  Inject,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Inject } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Cache } from 'cache-manager';
-import { ERR_MSG } from 'src/common/constants/errors';
 import { ProviderIdEnum, ProviderName } from 'src/common/constants/etc';
+import { CustomException } from 'src/exceptions';
+import { AUTH_CODEMAP } from 'src/exceptions/codemap';
 import { Member } from 'src/members/entities';
 import { Repository } from 'typeorm';
 import { JwtPayloadDto, OAuthTokenDto, ProfileDto } from '../dto';
@@ -103,21 +100,22 @@ export class MockedKakaoAuthService extends AuthService {
     if (authCodes.includes(code)) {
       return tokens[code];
     }
-    throw new UnauthorizedException(ERR_MSG.OAUTH_KAKAO_TOKEN_FAILED);
+    throw new CustomException(AUTH_CODEMAP.KAKAO_TOKEN_REQUEST_FAILED);
   }
 
   private refreshToken(refreshToken: string): KakaoTokenDto {
     if (refreshToken === correctRefreshToken) {
       return tokens.code;
     }
-    throw new UnauthorizedException(ERR_MSG.OAUTH_KAKAO_TOKEN_FAILED);
+    throw new CustomException(AUTH_CODEMAP.KAKAO_TOKEN_REFRESH_FAILED);
   }
 
   private getUser(accessToken: string): ProfileDto {
     if (accessToken === correctAccessToken) {
       return profile;
     }
-    throw new BadRequestException(ERR_MSG.OAUTH_KAKAO_USER_FAILED);
+    console.log(new CustomException(AUTH_CODEMAP.KAKAO_USER_FAILED));
+    throw new CustomException(AUTH_CODEMAP.KAKAO_USER_FAILED);
   }
 
   private getAccessTokenInfo(accessToken: string): KakaoAccessTokenInfoDto {

--- a/backend/was/src/auth/__mocks__/kakao.auth.service.ts
+++ b/backend/was/src/auth/__mocks__/kakao.auth.service.ts
@@ -114,7 +114,6 @@ export class MockedKakaoAuthService extends AuthService {
     if (accessToken === correctAccessToken) {
       return profile;
     }
-    console.log(new CustomException(AUTH_CODEMAP.KAKAO_USER_FAILED));
     throw new CustomException(AUTH_CODEMAP.KAKAO_USER_FAILED);
   }
 

--- a/backend/was/src/chat/chat.service.spec.ts
+++ b/backend/was/src/chat/chat.service.spec.ts
@@ -1,8 +1,9 @@
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProviderIdEnum } from 'src/common/constants/etc';
 import { ChatLog } from 'src/common/types/chatbot';
 import { UserInfo } from 'src/common/types/socket';
+import { CustomException } from 'src/exceptions';
+import { CHAT_CODEMAP } from 'src/exceptions/codemap';
 import { Member } from 'src/members/entities';
 import { EntityManager } from 'typeorm';
 import { ChatService } from './chat.service';
@@ -181,12 +182,15 @@ describe('ChatService', () => {
         const transactionMock = jest
           .spyOn(entityManager, 'transaction')
           .mockImplementation(
-            async () => await Promise.reject(new NotFoundException()),
+            async () =>
+              await Promise.reject(
+                new CustomException(CHAT_CODEMAP.ROOM_NOT_FOUND),
+              ),
           );
 
         await expect(
           chatService.createMessages(roomId, memberId, []),
-        ).rejects.toThrow(NotFoundException);
+        ).rejects.toThrow(new CustomException(CHAT_CODEMAP.ROOM_NOT_FOUND));
         expect(transactionMock).toHaveBeenCalled();
       }
     });
@@ -319,7 +323,10 @@ describe('ChatService', () => {
         const transactionMock = jest
           .spyOn(entityManager, 'transaction')
           .mockImplementation(
-            async () => await Promise.reject(new NotFoundException()),
+            async () =>
+              await Promise.reject(
+                new CustomException(CHAT_CODEMAP.ROOM_NOT_FOUND),
+              ),
           );
 
         await expect(
@@ -328,7 +335,7 @@ describe('ChatService', () => {
             member.email ?? '',
             member.providerId ?? 0,
           ),
-        ).rejects.toThrow(NotFoundException);
+        ).rejects.toThrow(new CustomException(CHAT_CODEMAP.ROOM_NOT_FOUND));
         expect(transactionMock).toHaveBeenCalled();
       });
 
@@ -342,7 +349,10 @@ describe('ChatService', () => {
         const transactionMock = jest
           .spyOn(entityManager, 'transaction')
           .mockImplementation(
-            async () => await Promise.reject(new ForbiddenException()),
+            async () =>
+              await Promise.reject(
+                new CustomException(CHAT_CODEMAP.ROOM_FORBIDDEN),
+              ),
           );
 
         await expect(
@@ -351,7 +361,7 @@ describe('ChatService', () => {
             forbiddenMember.email ?? '',
             forbiddenMember.providerId ?? 0,
           ),
-        ).rejects.toThrow(ForbiddenException);
+        ).rejects.toThrow(new CustomException(CHAT_CODEMAP.ROOM_FORBIDDEN));
         expect(transactionMock).toHaveBeenCalled();
       });
     });
@@ -402,7 +412,10 @@ describe('ChatService', () => {
         const transactionMock = jest
           .spyOn(entityManager, 'transaction')
           .mockImplementation(
-            async () => await Promise.reject(new NotFoundException()),
+            async () =>
+              await Promise.reject(
+                new CustomException(CHAT_CODEMAP.ROOM_NOT_FOUND),
+              ),
           );
 
         await expect(
@@ -412,7 +425,7 @@ describe('ChatService', () => {
             member.providerId ?? 0,
             updateRoomDto,
           ),
-        ).rejects.toThrow(NotFoundException);
+        ).rejects.toThrow(new CustomException(CHAT_CODEMAP.ROOM_NOT_FOUND));
         expect(transactionMock).toHaveBeenCalled();
       });
 
@@ -426,7 +439,10 @@ describe('ChatService', () => {
         const transactionMock = jest
           .spyOn(entityManager, 'transaction')
           .mockImplementation(
-            async () => await Promise.reject(new ForbiddenException()),
+            async () =>
+              await Promise.reject(
+                new CustomException(CHAT_CODEMAP.ROOM_FORBIDDEN),
+              ),
           );
 
         await expect(
@@ -436,7 +452,7 @@ describe('ChatService', () => {
             forbiddenMember.providerId ?? 0,
             updateRoomDto,
           ),
-        ).rejects.toThrow(ForbiddenException);
+        ).rejects.toThrow(new CustomException(CHAT_CODEMAP.ROOM_FORBIDDEN));
         expect(transactionMock).toHaveBeenCalled();
       });
     });
@@ -481,7 +497,10 @@ describe('ChatService', () => {
         const transactionMock = jest
           .spyOn(entityManager, 'transaction')
           .mockImplementation(
-            async () => await Promise.reject(new NotFoundException()),
+            async () =>
+              await Promise.reject(
+                new CustomException(CHAT_CODEMAP.ROOM_NOT_FOUND),
+              ),
           );
 
         await expect(
@@ -490,7 +509,7 @@ describe('ChatService', () => {
             member.email ?? '',
             member.providerId ?? 0,
           ),
-        ).rejects.toThrow(NotFoundException);
+        ).rejects.toThrow(new CustomException(CHAT_CODEMAP.ROOM_NOT_FOUND));
         expect(transactionMock).toHaveBeenCalled();
       });
 
@@ -504,7 +523,10 @@ describe('ChatService', () => {
         const transactionMock = jest
           .spyOn(entityManager, 'transaction')
           .mockImplementation(
-            async () => await Promise.reject(new ForbiddenException()),
+            async () =>
+              await Promise.reject(
+                new CustomException(CHAT_CODEMAP.ROOM_FORBIDDEN),
+              ),
           );
 
         await expect(
@@ -513,7 +535,7 @@ describe('ChatService', () => {
             forbiddenMember.email ?? '',
             forbiddenMember.providerId ?? 0,
           ),
-        ).rejects.toThrow(ForbiddenException);
+        ).rejects.toThrow(new CustomException(CHAT_CODEMAP.ROOM_FORBIDDEN));
         expect(transactionMock).toHaveBeenCalled();
       });
     });

--- a/backend/was/src/chat/chat.service.ts
+++ b/backend/was/src/chat/chat.service.ts
@@ -1,11 +1,7 @@
-import {
-  BadRequestException,
-  ForbiddenException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
-import { ERR_MSG } from 'src/common/constants/errors';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { UserInfo } from 'src/common/types/socket';
+import { CustomException } from 'src/exceptions';
+import { CHAT_CODEMAP } from 'src/exceptions/codemap';
 import { Member } from 'src/members/entities';
 import { EntityManager } from 'typeorm';
 import { ChattingInfo } from './chatting-info.interface';
@@ -224,10 +220,10 @@ export class ChatService {
         select: ['id', 'participant'],
       });
       if (!room) {
-        throw new NotFoundException(ERR_MSG.CHATTING_ROOM_NOT_FOUND);
+        throw new CustomException(CHAT_CODEMAP.ROOM_NOT_FOUND);
       }
       if (room.participant.id !== memberId) {
-        throw new ForbiddenException(ERR_MSG.UPDATE_CHATTING_ROOM_FORBIDDEN);
+        throw new CustomException(CHAT_CODEMAP.ROOM_UPDATE_FORBIDDEN);
       }
       return room;
     } catch (err: unknown) {

--- a/backend/was/src/chat/chat.service.ts
+++ b/backend/was/src/chat/chat.service.ts
@@ -223,7 +223,7 @@ export class ChatService {
         throw new CustomException(CHAT_CODEMAP.ROOM_NOT_FOUND);
       }
       if (room.participant.id !== memberId) {
-        throw new CustomException(CHAT_CODEMAP.ROOM_UPDATE_FORBIDDEN);
+        throw new CustomException(CHAT_CODEMAP.ROOM_FORBIDDEN);
       }
       return room;
     } catch (err: unknown) {

--- a/backend/was/src/common/constants/apis.ts
+++ b/backend/was/src/common/constants/apis.ts
@@ -13,9 +13,7 @@ export const OAUTH_URL = {
    */
   KAKAO_USER: 'https://kapi.kakao.com/v2/user/me',
   KAKAO_TOKEN: 'https://kauth.kakao.com/oauth/token',
-  KAKAO_ID_TOKEN: 'https://kauth.kakao.com/oauth/tokeninfo',
   KAKAO_ACCESS_TOKEN: 'https://kapi.kakao.com/v1/user/access_token_info',
-  KAKAO_OIDC_USERINFO: 'https://kapi.kakao.com/v1/oidc/userinfo',
   KAKAO_LOGOUT: 'https://kapi.kakao.com/v1/user/logout',
   KAKAO_LOGOUT_ALL: 'https://kauth.kakao.com/oauth/logout',
 };

--- a/backend/was/src/common/constants/errors.ts
+++ b/backend/was/src/common/constants/errors.ts
@@ -1,33 +1,5 @@
 export const ERR_MSG = {
   /**
-   * auth
-   */
-  UNAUTHORIZED_USER: '로그인이 필요한 서비스입니다.',
-
-  /**
-   * chat
-   */
-  CHATTING_ROOM_NOT_FOUND: '채팅방을 찾을 수 없습니다.',
-  UPDATE_CHATTING_ROOM_FORBIDDEN: '채팅방을 수정할 수 없습니다.',
-  DELETE_CHATTING_ROOM_FORBIDDEN: '채팅방을 삭제할 수 없습니다.',
-
-  /**
-   * tarot
-   */
-  TAROT_CARD_NOT_FOUND: '타로 카드를 찾을 수 없습니다.',
-  TAROT_RESULT_NOT_FOUND: '타로 결과를 찾을 수 없습니다.',
-
-  /**
-   * oauth
-   */
-  OAUTH_KAKAO_TOKEN_FAILED: '카카오 토큰 발급에 실패했습니다.',
-  OAUTH_KAKAO_USER_FAILED: '카카오 사용자 정보 조회에 실패했습니다.',
-  OAUTH_KAKAO_ACCESS_TOKEN_INFO_KAKAO_ERROR:
-    '카카오 플랫폼에서 일시적인 장애가 발생했습니다.',
-  OAUTH_KAKAO_ACCESS_TOKEN_INFO_BAD_REQUEST:
-    '카카오 액세스 토큰 정보 조회에 실패했습니다.',
-
-  /**
    * chatbot
    */
   USER_CHAT_MESSAGE_INPUT_EMPTY: '사용자 입력한 채팅 메세지가 비어있습니다.',

--- a/backend/was/src/exceptions/codemap/auth-codemap.ts
+++ b/backend/was/src/exceptions/codemap/auth-codemap.ts
@@ -1,0 +1,50 @@
+import { ExceptionCodemap } from './type';
+
+export const AUTH_CODEMAP: ExceptionCodemap = {
+  /**
+   * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token
+   */
+  KAKAO_TOKEN_REQUEST_FAILED: {
+    status: 400,
+    message: '카카오 로그인에 실패했습니다.',
+    code: 'MAE001',
+    description: '카카오 토큰 발급에 실패했습니다.',
+  },
+  /**
+   * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#refresh-token
+   */
+  KAKAO_TOKEN_REFRESH_FAILED: {
+    status: 400,
+    message: '카카오 로그아웃에 실패했습니다.',
+    code: 'MAE002',
+    description: '카카오 토큰 갱신에 실패했습니다.',
+  },
+  /**
+   * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
+   */
+  KAKAO_USER_FAILED: {
+    status: 400,
+    message: '카카오 로그인에 실패했습니다.',
+    code: 'MAE003',
+    description: '카카오 사용자 정보 조회에 실패했습니다.',
+  },
+  /**
+   * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#get-token-info
+   */
+  KAKAO_PLATFORM_ERROR: {
+    status: 500,
+    message: '카카오 로그아웃에 실패했습니다.',
+    code: 'MAE004',
+    description: '카카오 플랫폼에서 일시적인 장애가 발생했습니다.',
+  },
+  /**
+   * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#get-token-info
+   */
+  KAKAO_INVALID_ACCESS_TOKEN: {
+    status: 500,
+    message: '카카오 로그아웃에 실패했습니다.',
+    code: 'MAE005',
+    description:
+      '카카오 액세스 토큰 정보 조회에 실패했습니다. 요청에 포함된 파라미터와 액세스 토큰을 확인해주세요.',
+  },
+};

--- a/backend/was/src/exceptions/codemap/chat-codemap.ts
+++ b/backend/was/src/exceptions/codemap/chat-codemap.ts
@@ -1,0 +1,24 @@
+import { ExceptionCodemap } from './type';
+
+export const CHAT_CODEMAP: ExceptionCodemap = {
+  ROOM_NOT_FOUND: {
+    status: 404,
+    message: '채팅방을 찾을 수 없습니다.',
+    code: 'MCE001',
+    description: '요청에 포함된 채팅방 아이디가 존재하지 않습니다.',
+  },
+  ROOM_UPDATE_FORBIDDEN: {
+    status: 403,
+    message: '채팅방을 수정할 수 없습니다.',
+    code: 'MCE002',
+    description:
+      '요청한 사용자가 해당 채팅방의 수정 권한을 가지고 있지 않습니다.',
+  },
+  ROOM_DELETE_FORBIDDEN: {
+    status: 403,
+    message: '채팅방을 삭제할 수 없습니다.',
+    code: 'MCE003',
+    description:
+      '요청한 사용자가 해당 채팅방의 삭제 권한을 가지고 있지 않습니다.',
+  },
+};

--- a/backend/was/src/exceptions/codemap/chat-codemap.ts
+++ b/backend/was/src/exceptions/codemap/chat-codemap.ts
@@ -7,18 +7,11 @@ export const CHAT_CODEMAP: ExceptionCodemap = {
     code: 'MCE001',
     description: '요청에 포함된 채팅방 아이디가 존재하지 않습니다.',
   },
-  ROOM_UPDATE_FORBIDDEN: {
+  ROOM_FORBIDDEN: {
     status: 403,
-    message: '채팅방을 수정할 수 없습니다.',
+    message: '채팅방을 수정/삭제할 수 없습니다.',
     code: 'MCE002',
     description:
-      '요청한 사용자가 해당 채팅방의 수정 권한을 가지고 있지 않습니다.',
-  },
-  ROOM_DELETE_FORBIDDEN: {
-    status: 403,
-    message: '채팅방을 삭제할 수 없습니다.',
-    code: 'MCE003',
-    description:
-      '요청한 사용자가 해당 채팅방의 삭제 권한을 가지고 있지 않습니다.',
+      '요청한 사용자가 해당 채팅방의 수정/삭제 권한을 가지고 있지 않습니다.',
   },
 };

--- a/backend/was/src/exceptions/codemap/index.ts
+++ b/backend/was/src/exceptions/codemap/index.ts
@@ -1,0 +1,3 @@
+export * from './auth-codemap';
+export * from './chat-codemap';
+export * from './tarot-codemap';

--- a/backend/was/src/exceptions/codemap/tarot-codemap.ts
+++ b/backend/was/src/exceptions/codemap/tarot-codemap.ts
@@ -1,0 +1,17 @@
+import { ExceptionCodemap } from './type';
+
+export const TAROT_CODEMAP: ExceptionCodemap = {
+  CARD_NOT_FOUND: {
+    status: 404,
+    message: '타로 카드를 찾을 수 없습니다.',
+    code: 'MTE001',
+    description:
+      '요청에 포함된 타로 카드 번호가 존재하지 않습니다. 해당 번호가 타로 카드 범위 내에 속하는지 확인해주세요.',
+  },
+  RESULT_NOT_FOUND: {
+    status: 404,
+    message: '타로 결과를 찾을 수 없습니다.',
+    code: 'MTE002',
+    description: '요청에 포함된 타로 결과 아이디가 존재하지 않습니다.',
+  },
+};

--- a/backend/was/src/exceptions/codemap/type.ts
+++ b/backend/was/src/exceptions/codemap/type.ts
@@ -1,0 +1,3 @@
+import { ExceptionMetadata } from '../metadata';
+
+export type ExceptionCodemap = Record<string, ExceptionMetadata>;

--- a/backend/was/src/exceptions/custom-exception.ts
+++ b/backend/was/src/exceptions/custom-exception.ts
@@ -1,0 +1,11 @@
+import { HttpException } from '@nestjs/common';
+import { ExceptionMetadata } from './metadata';
+
+/**
+ * https://github.com/nestjs/nest/blob/master/packages/common/exceptions/http.exception.ts
+ */
+export class CustomException extends HttpException {
+  constructor({ status, message, code, description }: ExceptionMetadata) {
+    super({ message, code, description }, status);
+  }
+}

--- a/backend/was/src/exceptions/index.ts
+++ b/backend/was/src/exceptions/index.ts
@@ -1,0 +1,1 @@
+export * from './custom-exception';

--- a/backend/was/src/exceptions/metadata.ts
+++ b/backend/was/src/exceptions/metadata.ts
@@ -1,0 +1,6 @@
+export interface ExceptionMetadata {
+  status: number;
+  message: string;
+  code: string;
+  description?: string;
+}

--- a/backend/was/src/tarot/tarot.service.spec.ts
+++ b/backend/was/src/tarot/tarot.service.spec.ts
@@ -1,7 +1,8 @@
-import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { BUCKET_URL, ExtEnum } from 'src/common/constants/etc';
+import { CustomException } from 'src/exceptions';
+import { TAROT_CODEMAP } from 'src/exceptions/codemap';
 import { Repository } from 'typeorm';
 import { CreateTarotResultDto, TarotCardDto, TarotResultDto } from './dto';
 import { TarotCard, TarotResult } from './entities';
@@ -140,7 +141,7 @@ describe('TarotService', () => {
 
         await expect(
           tarotService.findTarotCardByCardNo(cardNo),
-        ).rejects.toThrow(NotFoundException);
+        ).rejects.toThrow(new CustomException(TAROT_CODEMAP.CARD_NOT_FOUND));
         expect(findOneMock).toHaveBeenCalledWith({
           where: {
             cardNo: cardNo,
@@ -202,7 +203,7 @@ describe('TarotService', () => {
           .mockResolvedValueOnce(null);
 
         await expect(tarotService.findTarotResultById(id)).rejects.toThrow(
-          NotFoundException,
+          new CustomException(TAROT_CODEMAP.RESULT_NOT_FOUND),
         );
         expect(findOneMock).toHaveBeenCalledWith({
           where: { id: id },

--- a/backend/was/src/tarot/tarot.service.ts
+++ b/backend/was/src/tarot/tarot.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { ERR_MSG } from 'src/common/constants/errors';
+import { CustomException } from 'src/exceptions';
+import { TAROT_CODEMAP } from 'src/exceptions/codemap';
 import { Repository } from 'typeorm';
 import { CreateTarotResultDto, TarotCardDto, TarotResultDto } from './dto';
 import { TarotCard, TarotResult } from './entities';
@@ -42,7 +43,7 @@ export class TarotService {
         });
 
       if (!tarotCard) {
-        throw new NotFoundException(ERR_MSG.TAROT_CARD_NOT_FOUND);
+        throw new CustomException(TAROT_CODEMAP.CARD_NOT_FOUND);
       }
       return TarotCardDto.fromEntity(tarotCard);
     } catch (err: unknown) {
@@ -58,7 +59,7 @@ export class TarotService {
           select: ['cardUrl', 'message'],
         });
       if (!tarotResult) {
-        throw new NotFoundException(ERR_MSG.TAROT_RESULT_NOT_FOUND);
+        throw new CustomException(TAROT_CODEMAP.RESULT_NOT_FOUND);
       }
       return TarotResultDto.fromEntity(tarotResult);
     } catch (err: unknown) {

--- a/backend/was/test/auth.e2e-spec.ts
+++ b/backend/was/test/auth.e2e-spec.ts
@@ -11,7 +11,6 @@ import { JwtAuthGuard, SocketJwtAuthGuard } from 'src/auth/guard';
 import { AuthService, KakaoAuthService } from 'src/auth/service';
 import { JwtStrategy } from 'src/auth/strategies/jwt.strategy';
 import { RedisCacheModule } from 'src/common/config/cache/redis-cache.module';
-import { ERR_MSG } from 'src/common/constants/errors';
 import { Member } from 'src/members/entities';
 import * as request from 'supertest';
 import { jwtToken } from './common/constants';
@@ -122,27 +121,19 @@ describe('Auth', () => {
           scenario: '잘못된 인증 코드를 받으면 401번 에러를 반환한다.',
           route: `/oauth/login/kakao?code=${wrongCode}`,
           status: 401,
-          message: ERR_MSG.OAUTH_KAKAO_TOKEN_FAILED,
         },
         {
           scenario: '사용자 정보 조회에 실패하면 400번 에러를 반환한다.',
           route: `/oauth/login/kakao?code=${codeGetUserFail}`,
           status: 400,
-          message: ERR_MSG.OAUTH_KAKAO_USER_FAILED,
         },
-      ].forEach(({ scenario, route, cookie, status, message }) => {
+      ].forEach(({ scenario, route, cookie, status }) => {
         it(scenario, () => {
           if (cookie) {
             return request(app.getHttpServer())
               .get(route)
               .set('Cookie', cookie)
               .expect(status);
-          }
-          if (message) {
-            return request(app.getHttpServer())
-              .get(route)
-              .expect(status)
-              .expect((res) => expect(res.body.message).toBe(message));
           }
           return request(app.getHttpServer()).get(route).expect(status);
         });

--- a/backend/was/test/auth.e2e-spec.ts
+++ b/backend/was/test/auth.e2e-spec.ts
@@ -120,7 +120,7 @@ describe('Auth', () => {
         {
           scenario: '잘못된 인증 코드를 받으면 401번 에러를 반환한다.',
           route: `/oauth/login/kakao?code=${wrongCode}`,
-          status: 401,
+          status: 400,
         },
         {
           scenario: '사용자 정보 조회에 실패하면 400번 에러를 반환한다.',


### PR DESCRIPTION
🔮 resolved #569
### 변경 사항
- 커스텀 에러를 위한 인터페이스 정의
- 모듈별 커스텀 에러 코드 정의
- 커스텀 에러 적용에 따른 테스트 파일 수정

### 고민과 해결 과정

#### 1️⃣ 예외 메타데이터
[kakao developers](https://developers.kakao.com/docs/latest/ko/kakaologin/trouble-shooting)를 참고하여 커스텀 에러를 작성했다. 커스텀 에러는 다음 구조를 갖는다.

```ts
export interface ExceptionMetadata {
  status: number;        // HTTP 응답 코드
  message: string;       // HTTP 에러 메시지
  code: string;          // 커스텀 에러 코드
  description?: string;  // 에러에 대한 부연설명
}
```
사용자에게는 `message`만 표기하여 민감한 정보를 노출하지 않고, 개발자는 고유한 에러 코드를 통해 원인을 빠르게 파악할 수 있다. 아래는 에러코드의 예시다. 사용자에게는 `로그인 실패`에 대한 메시지만 전달하여 구체적인 에러에 대한 정보를 노출하지 않는다.
```ts
export const AUTH_CODEMAP: ExceptionCodemap = {
  KAKAO_TOKEN_REQUEST_FAILED: {
    status: 400,
    message: '카카오 로그인에 실패했습니다.',
    code: 'MAE001',
    description: '카카오 토큰 발급에 실패했습니다.',
  },
  ...
}
```

#### 2️⃣ 고유 에러코드

고유 에러코드의 명명 규칙인 다음과 같다. 카카오의 경우, `KOE001` 형태의 에러코드를 사용하고 있는데 이와 유사하게 작성했다.

```
M(모듈)E(세 자리 번호)
ex. MCE001
```

- `M` : 마법의 소라고둥의 앞 글자
- `(모듈)` : 모듈의 첫 글자 (현재 프로젝트 기준, 모듈명이 겹치지 않아 사용 가능)
- `E` : 에러


### (선택) 테스트 결과