### PR TITLE
Fe/bugfix/#584 최초 로그인 시 카카오톡 로그인 후 쿠키가 붙지 않음

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -3,9 +3,24 @@ module.exports = {
     browser: true,
     es2021: true,
   },
-  extends: ['plugin:pretter/recommended', 'plugin:react/recommended', 'plugin:react-hooks/recommended', 'plugin:@typescript-eslint/recommended', 'airbnb-typescript', 'plugin:import/recommended', 'prettier', 'plugin:storybook/recommended'],
-  plugins: ['prettier', 'react-refresh', 'import', 'eslint:recommended'],
+  extends: [
+    'plugin:prettier/recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'airbnb-typescript',
+    'plugin:import/recommended',
+    'prettier',
+    'plugin:storybook/recommended',
+    'eslint:recommended',
+  ],
+  plugins: ['prettier', 'react-refresh', 'import'],
   ignorePatterns: ['dist', '.eslintrc.cjs', 'vite.config.ts'],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
 
   parser: '@typescript-eslint/parser',
   parserOptions: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,6 @@
     "@trivago/prettier-plugin-sort-imports": "4.1.1",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
-    "@types/socket.io-client": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.11.0",
     "@vitejs/plugin-react": "^4.2.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -91,9 +91,6 @@ devDependencies:
   '@types/react-dom':
     specifier: ^18.2.15
     version: 18.2.15
-  '@types/socket.io-client':
-    specifier: ^3.0.0
-    version: 3.0.0
   '@typescript-eslint/eslint-plugin':
     specifier: ^6.11.0
     version: 6.11.0(@typescript-eslint/parser@6.11.0)(eslint@8.53.0)(typescript@5.2.2)
@@ -3158,6 +3155,7 @@ packages:
 
   /@socket.io/component-emitter@3.1.0:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
+    dev: false
 
   /@storybook/addon-actions@7.5.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-v3yL6Eq/jCiXfA24JjRdbEQUuorms6tmrywaKcd1tAy4Ftgof0KHB4tTcTyiajrI5bh6PVJoRBkE8IDqmNAHkA==}
@@ -4478,17 +4476,6 @@ packages:
       '@types/http-errors': 2.0.4
       '@types/mime': 3.0.4
       '@types/node': 20.9.0
-    dev: true
-
-  /@types/socket.io-client@3.0.0:
-    resolution: {integrity: sha512-s+IPvFoEIjKA3RdJz/Z2dGR4gLgysKi8owcnrVwNjgvc01Lk68LJDDsG2GRqegFITcxmvCMYM7bhMpwEMlHmDg==}
-    deprecated: This is a stub types definition. socket.io-client provides its own type definitions, so you do not need this installed.
-    dependencies:
-      socket.io-client: 4.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: true
 
   /@types/statuses@2.0.4:
@@ -6066,10 +6053,12 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: false
 
   /engine.io-parser@5.2.1:
     resolution: {integrity: sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==}
     engines: {node: '>=10.0.0'}
+    dev: false
 
   /entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -9941,6 +9930,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: false
 
   /socket.io-parser@4.2.4:
     resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
@@ -9950,6 +9940,7 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
@@ -11188,6 +11179,7 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: false
 
   /ws@8.14.2:
     resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
@@ -11227,6 +11219,7 @@ packages:
   /xmlhttprequest-ssl@2.0.0:
     resolution: {integrity: sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==}
     engines: {node: '>=0.4.0'}
+    dev: false
 
   /xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}

--- a/frontend/src/business/hooks/auth/useKakaoOAuthRedirect.ts
+++ b/frontend/src/business/hooks/auth/useKakaoOAuthRedirect.ts
@@ -11,6 +11,10 @@ export function useKakaoOAuthRedirect() {
     const res = await axios.get(KAKAO_LOGIN_URL, {
       params: { code },
       withCredentials: true,
+      headers: {
+        SameSite: 'None',
+        Secure: true,
+      },
     });
 
     if (!res || res.status !== 200) {

--- a/frontend/src/business/hooks/auth/useKakaoOAuthRedirect.ts
+++ b/frontend/src/business/hooks/auth/useKakaoOAuthRedirect.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 
+import { isProdctionMode } from '@utils/env';
+
 import { KAKAO_LOGIN_URL } from '@constants/kakao';
 
 export function useKakaoOAuthRedirect() {
@@ -13,7 +15,7 @@ export function useKakaoOAuthRedirect() {
       withCredentials: true,
       headers: {
         SameSite: 'None',
-        Secure: true,
+        Secure: isProdctionMode(),
       },
     });
 

--- a/frontend/src/utils/env.ts
+++ b/frontend/src/utils/env.ts
@@ -1,0 +1,3 @@
+export function isProdctionMode() {
+  return import.meta.env.MODE === 'production';
+}


### PR DESCRIPTION
🔮 resolved #584
### 변경 사항
- 클라이언트에서 서버에 로그인 요청 시 SameSite 헤더 설정을 추가함.

### 고민과 해결 과정

#### 1️⃣ 원인
![image](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/0936a2d2-a727-4c99-b3db-02865c73303c)
```
This attempt to set a cookie via a Set-Cookie header was blocked because it had the "SameSite=Lax" attribute but came from a cross-site response which was not the response to a top-level navigation.
```

로그인을 하는 과정에서 위와 같은 경고 문구가 떴음.

이는 현재 클라이언트에서 서버로 로그인 요청을 보낼 때 서버가 쿠키 설정을 해주게 되는데
지금은 요청의 헤더의 `SameSite` 속성이 기본 값인 `Lax`로 설정되어 있기 때문이다.

`SameSite=Lax`는 보안 상의 이유로 쿠키 전송을 일부 제한하는데, 다른 사이트에서 쿠키 설정을 하려고 하면 차단하게 된다...

그래서 `localhost` 설정에서는 정상적으로 동작했지만, `web09-magicconch.pages.dev`와 `was.magicconch.com`끼리에서는 제대로 동작하지 않았던 것이다.

#### 2️⃣ 간단하게 해결

```diff
 const res = await axios.get(KAKAO_LOGIN_URL, {
      params: { code },
      withCredentials: true,
+      headers: {
+        SameSite: 'None',
+        Secure: true,
+      },
    });
```

### (선택) 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

실제 배포 환경에서 제대로 돌아가는 지 확인해봐야 함