### PR TITLE
Be/bugfix/#587 채팅 메시지 조회 시 카드도 같이 보여야 함

### DIFF
--- a/.github/workflows/blue-green-cd.yml
+++ b/.github/workflows/blue-green-cd.yml
@@ -35,7 +35,7 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: ${{ secrets.SSH_PORT }}
-          source: "backend/.env,backend/*.sh,backend/compose*deploy.yml,backend/Dockerfile.nginx"
+          source: "backend/.env,backend/*.sh,backend/compose*deploy.yml,backend/*nginx*"
           target: "~/app/"
           overwrite: true
 

--- a/backend/Dockerfile.nginx
+++ b/backend/Dockerfile.nginx
@@ -1,5 +1,5 @@
 FROM nginx:1.18.0
 
-COPY --link config/nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --link nginx/default.conf /etc/nginx/conf.d/default.conf
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/backend/was/package.json
+++ b/backend/was/package.json
@@ -13,11 +13,11 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest --runInBand --verbose",
+    "test": "jest --runInBand",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand --verbose"
+    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand"
   },
   "lint-staged": {
     "{src,apps,libs,test}/**/*.ts": [
@@ -79,6 +79,7 @@
     "tsconfig-paths": "^4.2.0"
   },
   "jest": {
+    "verbose": true,
     "moduleDirectories": [
       "node_modules",
       "src"
@@ -99,7 +100,19 @@
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",
     "moduleNameMapper": {
-      "src/(.*)": "<rootDir>/$1"
+      "src/(.*)": "<rootDir>/$1",
+      "@auth/(.*)$": "<rootDir>/auth/$1",
+      "@chat/(.*)$": "<rootDir>/chat/$1",
+      "@chatbot/(.*)$": "<rootDir>/chatbot/$1",
+      "@common/(.*)$": "<rootDir>/common/$1",
+      "@config/(.*)$": "<rootDir>/common/config/$1",
+      "@constants/(.*)$": "<rootDir>/common/constants/$1",
+      "@interceptors/(.*)$": "<rootDir>/common/interceptors/$1",
+      "@exceptions/(.*)$": "<rootDir>/exceptions/$1",
+      "@logger/(.*)$": "<rootDir>/logger/$1",
+      "@members/(.*)$": "<rootDir>/members/$1",
+      "@socket/(.*)$": "<rootDir>/socket/$1",
+      "@tarot/(.*)$": "<rootDir>/tarot/$1"
     }
   }
 }

--- a/backend/was/src/auth/service/auth.service.spec.ts
+++ b/backend/was/src/auth/service/auth.service.spec.ts
@@ -3,7 +3,7 @@ import { Repository } from 'typeorm';
 import { JwtModule } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { RedisCacheModule } from '@common/config/cache/redis-cache.module';
+import { RedisCacheModule } from '@config/cache/redis-cache.module';
 import { ProviderIdEnum } from '@constants/etc';
 import { CreateMemberDto, UpdateMemberDto } from '@members/dto';
 import { Member } from '@members/entities';

--- a/backend/was/src/chat/chat.service.spec.ts
+++ b/backend/was/src/chat/chat.service.spec.ts
@@ -6,6 +6,7 @@ import { ProviderIdEnum } from '@constants/etc';
 import { CHAT_CODEMAP } from '@exceptions/codemap';
 import { CustomException } from '@exceptions/custom-exception';
 import { Member } from '@members/entities';
+import { TarotResult } from '@tarot/entities';
 import { ChatService } from './chat.service';
 import { ChattingInfo } from './chatting-info.interface';
 import {
@@ -22,6 +23,7 @@ const JAN_26: string = '2024-01-26';
 describe('ChatService', () => {
   let chatService: ChatService;
   let entityManager: EntityManager;
+  let result: TarotResult;
 
   beforeAll(async () => {
     const moduleRef: TestingModule = await Test.createTestingModule({
@@ -36,6 +38,11 @@ describe('ChatService', () => {
 
     chatService = moduleRef.get<ChatService>(ChatService);
     entityManager = moduleRef.get<EntityManager>(EntityManager);
+
+    result = new TarotResult();
+    result.id = '12345678-0000-0000-0000-567812345678';
+    result.cardUrl = 'cardUrl';
+    result.message = 'message';
   });
 
   afterAll(() => {
@@ -64,13 +71,14 @@ describe('ChatService', () => {
           const room: ChattingRoom = {
             id: roomId,
             participant: member,
+            result,
           };
 
           const transactionMock = jest
             .spyOn(entityManager, 'transaction')
             .mockImplementation(async () => Promise.resolve({ member, room }));
 
-          await expect(chatService.createRoom()).resolves.toEqual({
+          await expect(chatService.createRoom(result)).resolves.toEqual({
             memberId: member.id,
             roomId: room.id,
           });
@@ -102,6 +110,7 @@ describe('ChatService', () => {
           const room: ChattingRoom = {
             id: roomId,
             participant: member,
+            result,
           };
           const userInfo: UserInfo = {
             email: email ?? '',
@@ -112,8 +121,10 @@ describe('ChatService', () => {
             .spyOn(entityManager, 'transaction')
             .mockImplementation(async () => Promise.resolve({ member, room }));
 
-          const expectation: ChattingInfo =
-            await chatService.createRoom(userInfo);
+          const expectation: ChattingInfo = await chatService.createRoom(
+            result,
+            userInfo,
+          );
           expect(expectation).toEqual({
             memberId: memberId,
             roomId: roomId,
@@ -144,6 +155,7 @@ describe('ChatService', () => {
         const room: ChattingRoom = {
           id: roomId,
           participant: member,
+          result,
         };
         const chatLog: ChatLog = {
           isHost: messages.role === 'assistant',
@@ -204,12 +216,14 @@ describe('ChatService', () => {
           id: '12345678-1234-5678-1234-567812345672',
           title: '내일의 운세 채팅방',
           participant: member,
+          result,
           createdAt: jan26,
         },
         {
           id: '12345678-1234-5678-1234-567812345671',
           title: '오늘의 운세 채팅방',
           participant: member,
+          result,
           createdAt: jan15,
         },
       ];
@@ -270,6 +284,7 @@ describe('ChatService', () => {
       room = {
         id: '12345678-1234-5678-1234-567812345671',
         participant: member,
+        result,
       };
 
       messages = [
@@ -369,6 +384,7 @@ describe('ChatService', () => {
       room = {
         id: '12345678-1234-5678-1234-567812345671',
         participant: member,
+        result,
       };
 
       updateRoomDto = {
@@ -453,6 +469,7 @@ describe('ChatService', () => {
       room = {
         id: '12345678-1234-5678-1234-567812345671',
         participant: member,
+        result,
       };
     });
 

--- a/backend/was/src/chat/chat.service.ts
+++ b/backend/was/src/chat/chat.service.ts
@@ -190,7 +190,7 @@ export class ChatService {
             email,
             providerId,
           );
-          const room = await manager.save(
+          const room: ChattingRoom = await manager.save(
             ChattingRoom,
             ChattingRoom.fromInfo(result, member),
           );
@@ -210,7 +210,7 @@ export class ChatService {
       async (manager: EntityManager) => {
         try {
           const member: Member = await manager.save(Member, new Member());
-          const room = await manager.save(
+          const room: ChattingRoom = await manager.save(
             ChattingRoom,
             ChattingRoom.fromInfo(result, member),
           );

--- a/backend/was/src/chat/entities/chatting-message.entity.ts
+++ b/backend/was/src/chat/entities/chatting-message.entity.ts
@@ -47,4 +47,11 @@ export class ChattingMessage {
     message.order = order;
     return message;
   }
+
+  static formatResult(result: string): ChattingMessage {
+    const message: ChattingMessage = new ChattingMessage();
+    message.isHost = true;
+    message.message = result;
+    return message;
+  }
 }

--- a/backend/was/src/chat/entities/chatting-room.entity.ts
+++ b/backend/was/src/chat/entities/chatting-room.entity.ts
@@ -3,12 +3,15 @@ import {
   CreateDateColumn,
   DeleteDateColumn,
   Entity,
+  JoinColumn,
   ManyToOne,
   OneToMany,
+  OneToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { Member } from '@members/entities';
+import { TarotResult } from '@tarot/entities';
 import { ChattingMessage } from './chatting-message.entity';
 
 @Entity()
@@ -34,8 +37,13 @@ export class ChattingRoom {
   @ManyToOne(() => Member, (member) => member.chattingRooms, { eager: true })
   participant: Member;
 
-  static fromMember(member: Member): ChattingRoom {
+  @OneToOne(() => TarotResult, (result) => result.id, { eager: true })
+  @JoinColumn()
+  result: TarotResult;
+
+  static fromInfo(result: TarotResult, member: Member): ChattingRoom {
     const room = new ChattingRoom();
+    room.result = result;
     room.participant = member;
     return room;
   }

--- a/backend/was/src/common/types/socket.ts
+++ b/backend/was/src/common/types/socket.ts
@@ -1,4 +1,5 @@
 import { Server, Socket } from 'socket.io';
+import { TarotResult } from '@tarot/entities';
 import { ChatLog } from './chatbot';
 
 export interface UserInfo {
@@ -19,6 +20,7 @@ export interface AiSocket
   user?: UserInfo;
   chatLog: ChatLog[];
   chatEnd: boolean;
+  result?: TarotResult;
 }
 
 export type AiSocketClientEvent = keyof AiSocketEvent['ClientToServerEvent'];

--- a/backend/was/src/socket/socket.service.ts
+++ b/backend/was/src/socket/socket.service.ts
@@ -13,6 +13,7 @@ import { ChatService } from '@chat/chat.service';
 import { CreateChattingMessageDto } from '@chat/dto';
 import { ChatbotService } from '@chatbot/chatbot.interface';
 import { CreateTarotResultDto } from '@tarot/dto';
+import { TarotResult } from '@tarot/entities';
 import { TarotService } from '@tarot/tarot.service';
 
 @Injectable()
@@ -83,10 +84,11 @@ export class SocketService {
       );
 
       client.chatLog.push({ isHost: true, message: sentMessage });
-
       client.chatEnd = true;
 
-      const shareLinkId = await this.createShareLinkId(cardIdx, sentMessage);
+      client.result = await this.createResult(cardIdx, sentMessage);
+
+      const shareLinkId = client.result.id;
       client.emit('chatEnd', shareLinkId);
 
       const { memberId, roomId } = await this.createRoom(client);
@@ -122,7 +124,10 @@ export class SocketService {
 
   private async createRoom(client: AiSocket) {
     try {
-      const chattingInfo = await this.chatService.createRoom(client.user);
+      const chattingInfo = await this.chatService.createRoom(
+        client.result as TarotResult,
+        client.user,
+      );
       return chattingInfo;
     } catch (err) {
       if (err instanceof Error) {
@@ -160,10 +165,10 @@ export class SocketService {
     }
   }
 
-  private async createShareLinkId(
+  private async createResult(
     cardIdx: number,
     result: string,
-  ): Promise<string> {
+  ): Promise<TarotResult> {
     try {
       const tarotResult = CreateTarotResultDto.fromResult(cardIdx, result);
       return await this.tarotService.createTarotResult(tarotResult);

--- a/backend/was/src/tarot/tarot.service.ts
+++ b/backend/was/src/tarot/tarot.service.ts
@@ -17,12 +17,10 @@ export class TarotService {
 
   async createTarotResult(
     createTarotResultDto: CreateTarotResultDto,
-  ): Promise<string> {
+  ): Promise<TarotResult> {
     const tarotResult: TarotResult = TarotResult.fromDto(createTarotResultDto);
     try {
-      const savedResult: TarotResult =
-        await this.tarotResultRepository.save(tarotResult);
-      return savedResult.id;
+      return await this.tarotResultRepository.save(tarotResult);
     } catch (err: unknown) {
       throw err;
     }

--- a/backend/was/test/chat.e2e-spec.ts
+++ b/backend/was/test/chat.e2e-spec.ts
@@ -17,6 +17,7 @@ import {
 } from '@chat/dto';
 import { ChattingMessage, ChattingRoom } from '@chat/entities';
 import { Member } from '@members/entities';
+import { TarotResult } from '@tarot/entities';
 import { diffJwtToken, id, id2, jwtToken, wrongId } from './common/constants';
 import { SqliteModule } from './common/database/sqlite.module';
 
@@ -27,6 +28,7 @@ describe('Chat', () => {
   let app: INestApplication;
   let entityManager: EntityManager;
   let member: Member;
+  let savedResult: TarotResult;
   let savedRoom: ChattingRoom;
   const oneDay: Date = new Date(JAN_15);
   const anotherDay: Date = new Date(JAN_26);
@@ -35,7 +37,12 @@ describe('Chat', () => {
     const moduleRef = await Test.createTestingModule({
       imports: [
         SqliteModule,
-        TypeOrmModule.forFeature([ChattingRoom, ChattingMessage, Member]),
+        TypeOrmModule.forFeature([
+          ChattingRoom,
+          ChattingMessage,
+          Member,
+          TarotResult,
+        ]),
       ],
       providers: [ChatService, JwtAuthGuard, JwtStrategy],
       controllers: [ChatController],
@@ -55,11 +62,18 @@ describe('Chat', () => {
     diffMember.providerId = ProviderIdEnum.KAKAO;
     await entityManager.save(diffMember);
 
+    const result: TarotResult = new TarotResult();
+    result.cardUrl =
+      'https://kr.object.ncloudstorage.com/magicconch/basic/0.jpg';
+    result.message = '0번 카드에 대한 해설입니다.';
+    savedResult = await entityManager.save(result);
+
     const room: ChattingRoom = new ChattingRoom();
     room.id = id;
     room.title = `${JAN_15}일자 채팅방`;
     room.createdAt = oneDay;
     room.participant = member;
+    room.result = savedResult;
     savedRoom = await entityManager.save(room);
 
     app.use(cookieParser());
@@ -95,6 +109,7 @@ describe('Chat', () => {
                 id: id2,
                 title: `${JAN_26}일자 채팅방`,
                 createdAt: anotherDay.toLocaleDateString('ko-KR'),
+                result: savedResult,
               },
             ],
           },
@@ -105,6 +120,7 @@ describe('Chat', () => {
                 id,
                 title: `${JAN_15}일자 채팅방`,
                 createdAt: oneDay.toLocaleDateString('ko-KR'),
+                result: savedResult,
               },
             ],
           },
@@ -138,12 +154,12 @@ describe('Chat', () => {
         {
           isHost: true,
           message: '어떤 고민이 있어?',
-          order: 1,
+          order: 0,
         },
         {
           isHost: false,
           message: '오늘 운세를 알고 싶어',
-          order: 2,
+          order: 1,
         },
       ];
       for (const chatLog of chatLogs) {
@@ -155,6 +171,17 @@ describe('Chat', () => {
         await entityManager.save(message);
         messages.push(ChattingMessageDto.fromEntity(message));
       }
+      const resultMessages: ChattingMessage[] = [
+        ChattingMessage.formatResult(
+          'https://kr.object.ncloudstorage.com/magicconch/basic/0.jpg',
+        ),
+        ChattingMessage.formatResult('0번 카드에 대한 해설입니다.'),
+      ];
+      messages.push(
+        ...resultMessages.map((entity: ChattingMessage) =>
+          ChattingMessageDto.fromEntity(entity),
+        ),
+      );
     });
 
     it('인증 받은 사용자는 특정 채팅방에서 오간 메시지 목록을 조회할 수 있다.', () => {


### PR DESCRIPTION
🔮 resolved #587

### 변경사항
채팅 메시지 조회 시 카드도 같이 조회하도록 수정
→ `body[-1]` : 타로 결과 / `body[-2]` : 타로 카드 이미지 url

### 고민과 해결 과정
### (선택) 테스트 결과
```json
[
  { 
     "isHost": true, 
     "message": "어떤 고민이 있어?"
   },
  { 
    "isHost": false, 
    "message": "오늘 운세를 알고 싶어"
  },
  {
     "isHost": true,
     "message": "https://kr.object.ncloudstorage.com/magicconch/basic/0.jpg"
  },
  { 
    "isHost": true, 
    "message": "0번 카드에 대한 해설입니다."
  }
]
```