### PR TITLE
Be/refactor/#589 타로 해설 채팅 기록에 저장 안하기

### DIFF
--- a/backend/was/src/socket/socket.service.ts
+++ b/backend/was/src/socket/socket.service.ts
@@ -82,8 +82,6 @@ export class SocketService {
         this.chatbotService.generateTarotReading(client.chatLog, cardIdx),
       );
 
-      client.chatLog.push({ isHost: true, message: sentMessage });
-
       client.chatEnd = true;
 
       const shareLinkId = await this.createShareLinkId(cardIdx, sentMessage);


### PR DESCRIPTION
### 변경 사항
- [x] 타로 해설 채팅 기록에 저장 안하도록 수정

### 고민과 해결 과정
채팅 기록 저장하는 코드 한 줄만 삭제함.

### (선택) 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.