### PR TITLE
Fe/bugfix/#600 헤더가 잘려서 보이는 문제

### DIFF
--- a/frontend/src/business/hooks/overlay/useOverlay.tsx
+++ b/frontend/src/business/hooks/overlay/useOverlay.tsx
@@ -28,7 +28,7 @@ export function useOverlay() {
       openOverlay: (OverlayElement: CreateOverlayElement) => {
         mount(
           id,
-          <div className="fixed top-[50%] left-[50%] -translate-x-[50%] -translate-y-[50%] z-10">
+          <div className="fixed top-[50%] left-[50%] -translate-x-[50%] -translate-y-[50%] z-50">
             <OverlayElement
               key={String(new Date())}
               opened={opened}

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -6,7 +6,7 @@ interface HeaderProps {
 
 export function Header({ rightItems }: HeaderProps) {
   return (
-    <header className="sticky w-full h-48 flex justify-between items-center surface-content text-default px-8 py-5 z-50">
+    <header className="fixed top-0 w-full h-48 flex justify-between items-center surface-content text-default px-8 py-5 z-20">
       <LogoButton />
       {rightItems?.map((item, index) => (
         <div

--- a/frontend/src/pages/AIChatPage/AIChatPage.tsx
+++ b/frontend/src/pages/AIChatPage/AIChatPage.tsx
@@ -34,7 +34,7 @@ export function AIChatPage({}: AIChatPageProps) {
               : []
           }
         />
-        <div className="w-h-full pl-[5%] pr-[5%] pb-[5%] lg:pl-[25%] lg:pr-[25%]">
+        <div className="w-h-full pt-50 pl-[5%] pr-[5%] pb-[5%] lg:pl-[25%] lg:pr-[25%]">
           <ChatContainer
             messages={messages}
             inputDisabled={inputDisabled}


### PR DESCRIPTION
### 변경 사항
- [x] 헤더가 잘려서 보이는 문제 해결

### 고민과 해결 과정

- header 속성을 `sticky` -> `fixed`로 수정함
- overlay, sidebar와의 z-index 수정
  - overlay > header > sidebar 순서

### (선택) 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.