### PR TITLE
Fe/feature/#603 실시간 채팅 알림 기능

### DIFF
--- a/frontend/src/business/hooks/chatMessage/useHumanChatMessage.ts
+++ b/frontend/src/business/hooks/chatMessage/useHumanChatMessage.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { MessageButton } from '@components/common/ChatContainer';
 
-import { ProfileInfo, useProfileInfo } from '@stores/zustandStores';
+import { ProfileInfo, useProfileInfo, useToastStore } from '@stores/zustandStores';
 
 import { arrayBuffer2Blob } from '@utils/array';
 
@@ -21,6 +21,10 @@ export function useHumanChatMessage() {
 
   const myProfileRef = useRef<ProfileInfo>();
   const remoteProfileRef = useRef<ProfileInfo>();
+
+  const { setToastMessage } = useToastStore(state => ({
+    setToastMessage: state.setMessage,
+  }));
 
   const { myProfile, remoteProfile } = useProfileInfo(state => ({
     myProfile: state.myProfile,
@@ -69,6 +73,7 @@ export function useHumanChatMessage() {
 
         if (message.type === CHAT_MESSAGE) {
           addMessage('left', { message: message.content });
+          setToastMessage(message.content);
         }
         if (message.type === PICK_CARD) {
           addMessage('right', { tarotId: message.content });

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -1,5 +1,7 @@
 import { LogoButton } from '@components/common/Buttons';
 
+import Toast from './Toast';
+
 interface HeaderProps {
   rightItems?: React.ReactNode[];
 }
@@ -16,6 +18,7 @@ export function Header({ rightItems }: HeaderProps) {
           {item}
         </div>
       ))}
+      <Toast />
     </header>
   );
 }

--- a/frontend/src/components/common/Header/Toast/Toast.tsx
+++ b/frontend/src/components/common/Header/Toast/Toast.tsx
@@ -9,7 +9,7 @@ export function Toast() {
     <>
       {message && (
         <div
-          className="toast absolute top-[150%] right-20"
+          className="toast absolute top-[120%] right-20 animate-shining"
           onClick={removeToast}
         >
           <div className="alert w-fit">

--- a/frontend/src/components/common/Header/Toast/Toast.tsx
+++ b/frontend/src/components/common/Header/Toast/Toast.tsx
@@ -1,0 +1,26 @@
+import { Icon } from '@iconify/react/dist/iconify.js';
+
+import { useToast } from './hooks';
+
+export function Toast() {
+  const { message, removeToast } = useToast();
+
+  return (
+    <>
+      {message && (
+        <div
+          className="toast absolute top-[150%] right-20"
+          onClick={removeToast}
+        >
+          <div className="alert w-fit">
+            <Icon
+              icon="mingcute:message-3-fill"
+              width={24}
+            />
+            {message}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/common/Header/Toast/Toast.tsx
+++ b/frontend/src/components/common/Header/Toast/Toast.tsx
@@ -3,15 +3,12 @@ import { Icon } from '@iconify/react/dist/iconify.js';
 import { useToast } from './hooks';
 
 export function Toast() {
-  const { message, removeToast } = useToast();
+  const { message } = useToast();
 
   return (
     <>
       {message && (
-        <div
-          className="toast absolute top-[120%] right-20 animate-shining"
-          onClick={removeToast}
-        >
+        <div className="toast absolute top-[120%] right-20 animate-shining">
           <div className="alert w-fit">
             <Icon
               icon="mingcute:message-3-fill"

--- a/frontend/src/components/common/Header/Toast/hooks/index.ts
+++ b/frontend/src/components/common/Header/Toast/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useToast';

--- a/frontend/src/components/common/Header/Toast/hooks/useToast.ts
+++ b/frontend/src/components/common/Header/Toast/hooks/useToast.ts
@@ -1,11 +1,15 @@
 import { useEffect } from 'react';
 
-import { useToastStore } from '@stores/zustandStores';
+import { useSideBarStore, useToastStore } from '@stores/zustandStores';
 
 export function useToast() {
   const { message, removeToast } = useToastStore(state => ({
     message: state.message,
     removeToast: state.removeToast,
+  }));
+
+  const { sideBarState } = useSideBarStore(state => ({
+    sideBarState: state.sideBarState,
   }));
 
   useEffect(() => {
@@ -15,6 +19,10 @@ export function useToast() {
 
   useEffect(() => {
     if (!message) return;
+
+    if (sideBarState) {
+      removeToast();
+    }
 
     if (message) {
       const timeout = setTimeout(() => {

--- a/frontend/src/components/common/Header/Toast/hooks/useToast.ts
+++ b/frontend/src/components/common/Header/Toast/hooks/useToast.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { useSideBarStore, useToastStore } from '@stores/zustandStores';
+import { useToastStore } from '@stores/zustandStores';
 
 export function useToast() {
   const { message, removeToast } = useToastStore(state => ({
@@ -8,21 +8,10 @@ export function useToast() {
     removeToast: state.removeToast,
   }));
 
-  const { sideBarState } = useSideBarStore(state => ({
-    sideBarState: state.sideBarState,
-  }));
+  useEffect(removeToast, []);
 
   useEffect(() => {
     if (!message) return;
-    removeToast();
-  }, []);
-
-  useEffect(() => {
-    if (!message) return;
-
-    if (sideBarState) {
-      removeToast();
-    }
 
     if (message) {
       const timeout = setTimeout(() => {
@@ -32,5 +21,5 @@ export function useToast() {
     }
   }, [message]);
 
-  return { message, removeToast };
+  return { message };
 }

--- a/frontend/src/components/common/Header/Toast/hooks/useToast.ts
+++ b/frontend/src/components/common/Header/Toast/hooks/useToast.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+import { useToastStore } from '@stores/zustandStores';
+
+export function useToast() {
+  const { message, removeToast } = useToastStore(state => ({
+    message: state.message,
+    removeToast: state.removeToast,
+  }));
+
+  useEffect(() => {
+    if (!message) return;
+    removeToast();
+  }, []);
+
+  useEffect(() => {
+    if (!message) return;
+
+    if (message) {
+      const timeout = setTimeout(() => {
+        removeToast();
+      }, 2000);
+      return () => clearTimeout(timeout);
+    }
+  }, [message]);
+
+  return { message, removeToast };
+}

--- a/frontend/src/components/common/Header/Toast/index.ts
+++ b/frontend/src/components/common/Header/Toast/index.ts
@@ -1,0 +1,1 @@
+export { Toast as default } from './Toast';

--- a/frontend/src/components/common/Header/hooks/index.ts
+++ b/frontend/src/components/common/Header/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useAlert';

--- a/frontend/src/components/common/Header/hooks/index.ts
+++ b/frontend/src/components/common/Header/hooks/index.ts
@@ -1,1 +1,0 @@
-export * from './useAlert';

--- a/frontend/src/stores/zustandStores/index.ts
+++ b/frontend/src/stores/zustandStores/index.ts
@@ -3,3 +3,4 @@ export * from './useProfileInfo';
 export * from './useSideBarStore';
 export * from './useMediaStreamStore';
 export * from './useAiChatLogId';
+export * from './useToastStore';

--- a/frontend/src/stores/zustandStores/useToastStore.ts
+++ b/frontend/src/stores/zustandStores/useToastStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+interface ToastStoreState {
+  message: string | null;
+}
+
+interface ToastStoreActions {
+  setMessage: (message: string) => void;
+  removeToast: () => void;
+}
+
+const initialState: ToastStoreState = {
+  message: null,
+};
+
+export const useToastStore = create<ToastStoreState & ToastStoreActions>()(
+  devtools(set => ({
+    ...initialState,
+    setMessage: (message: string) => set(() => ({ message })),
+    removeToast: () => set(() => ({ message: null })),
+  })),
+);


### PR DESCRIPTION
### 변경 사항
- [x] 실시간 메세지가 왔을 때 알림 기능 추가

### 고민과 해결 과정
#### 1️⃣  Toast를 추가해서 채팅이 왔을 때 알림이 오도록 함
- Toast 메세지를 전역 상태로 빼놓고 어디서든 Toast를 띄울 수 있도록 함.

#### TODO: sidebar 관련 상호작용 추가가 필요함
- sidebar가 보여진 상태에서는 toast 띄우지 않기
- toast를 클릭할 때 sidebar 열기
- sidebar 버튼을 누르면 toast 끄기

-> sidebar 상태를 원래 전역으로 사용했었는데, 그 부분이 수정되어서 이 부분 어떻게 할지 생각해봐야 함.

### (선택) 테스트 결과
![녹화_2024_03_06_18_36_36_285](https://github.com/boostcampwm2023/web09-MagicConch/assets/78946499/6d0b791a-ca91-4632-84a3-abc4d0cea56a)
